### PR TITLE
The method util_update_path_var() is scheduled to be removed

### DIFF
--- a/lib/include/ert/util/util.h
+++ b/lib/include/ert/util/util.h
@@ -330,7 +330,6 @@ int util_type_get_id(const void *data);
 
 bool util_sscanf_bytesize(const char *, size_t *);
 int util_get_current_linenr(FILE *stream);
-const char *util_update_path_var(const char *, const char *, bool);
 
 void util_fskip_int(FILE *stream);
 void util_fskip_long(FILE *stream);


### PR DESCRIPTION
This method is scheduled to be removed from ERT. It doesn't seem to be used anywhere AFAICS.
