### PR TITLE
using new conan2 arguments format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ conan_cmake_run(
   fmt/8.0.1
   # Options
   OPTIONS
-  catch2:with_main=True
+  catch2/*:with_main=True
   ${conan_opts}
   # Force cppstd to be the same as this CMakeLists.txt's
   SETTINGS


### PR DESCRIPTION
**Issue**
cmake failure in Ubuntu 22.04 with conan 2: 
-- Conan executing: /home/kaib/.local/bin/conan install . -s build_type=RelWithDebInfo -s compiler=gcc -s compiler.version=11 -s compiler.libcxx=libstdc++11 -s compiler.cppstd=17 -g=cmake_find_package -g=cmake --build=missing -o=catch2:with_main=True
ERROR: Error while initializing options. The usage of package names `catch2:with_main` in options is deprecated, use a pattern like `catch2/*:with_main` instead


**Approach**
following the message