### PR TITLE
Use datetime.utcfromtimestamp instead of first using gmtime in CTime.datetime

### DIFF
--- a/python/ecl/util/util/ctime.py
+++ b/python/ecl/util/util/ctime.py
@@ -50,7 +50,7 @@ class CTime(BaseCValue):
         return datetime.date(*self.time()[0:3])
 
     def datetime(self):
-        return datetime.datetime(*self.time()[0:6])
+        return datetime.datetime.utcfromtimestamp(self.ctime())
 
     def __str__(self):
         return self.datetime().strftime("%Y-%m-%d %H:%M:%S%z")


### PR DESCRIPTION
This makes datetime run about 10% faster.

measured using this python code
```
import timeit

runtime = timeit.timeit(
    "time_map = [t.datetime() for t in c_time]",
    "from ecl.summary import EclSum;"
    'summary = EclSum("/home/jholba/Downloads/BIGPOLY",include_restart=False,lazy_load=False);'
    "c_time = summary.alloc_time_vector(True)",
    number=100,
)

print(runtime)
```
