### PR TITLE
make tests compatible with python3.11

### DIFF
--- a/python/tests/rd_tests/test_grid.py
+++ b/python/tests/rd_tests/test_grid.py
@@ -312,7 +312,7 @@ class GridTest(ResdataTest):
 
             size = os.path.getsize("TEST.EGRID")
             with open("TEST.EGRID", "r+") as f:
-                f.truncate(size / 2)
+                f.truncate(size // 2)
 
             with self.assertRaises(IOError):
                 Grid("TEST.EGRID")

--- a/python/tests/rd_tests/test_rd_sum.py
+++ b/python/tests/rd_tests/test_rd_sum.py
@@ -85,7 +85,7 @@ class SummaryTest(ResdataTest):
 
             file_size = os.path.getsize("ECLIPSE.SMSPEC")
             with open("ECLIPSE.SMSPEC", "r+") as f:
-                f.truncate(file_size / 2)
+                f.truncate(file_size // 2)
 
             with self.assertRaises(IOError):
                 Summary("ECLIPSE")
@@ -97,7 +97,7 @@ class SummaryTest(ResdataTest):
 
             file_size = os.path.getsize("ECLIPSE.UNSMRY")
             with open("ECLIPSE.UNSMRY", "r+") as f:
-                f.truncate(file_size / 2)
+                f.truncate(file_size // 2)
 
             with self.assertRaises(IOError):
                 Summary("ECLIPSE")


### PR DESCRIPTION
**Issue**
Resolves #946 

Converts filesize to int by using "//" instead of "/".