### PR TITLE
Remove unused c code

### DIFF
--- a/lib/geometry/geo_polygon.cpp
+++ b/lib/geometry/geo_polygon.cpp
@@ -132,21 +132,8 @@ void geo_polygon_reset(geo_polygon_type *polygon) {
     double_vector_reset(polygon->ycoord);
 }
 
-void geo_polygon_shift(geo_polygon_type *polygon, double x0, double y0) {
-    double_vector_shift(polygon->xcoord, x0);
-    double_vector_shift(polygon->ycoord, y0);
-}
-
 int geo_polygon_get_size(const geo_polygon_type *polygon) {
     return double_vector_size(polygon->xcoord);
-}
-
-void geo_polygon_fprintf(const geo_polygon_type *polygon, FILE *stream) {
-    int i;
-    for (i = 0; i < double_vector_size(polygon->xcoord); i++)
-        fprintf(stream, "%10.3f  %10.3f \n",
-                double_vector_iget(polygon->xcoord, i),
-                double_vector_iget(polygon->ycoord, i));
 }
 
 void geo_polygon_iget_xy(const geo_polygon_type *polygon, int index, double *x,

--- a/lib/geometry/geo_region.cpp
+++ b/lib/geometry/geo_region.cpp
@@ -70,11 +70,6 @@ void geo_region_free(geo_region_type *region) {
     free(region);
 }
 
-void geo_region_free__(void *arg) {
-    geo_region_type *region = geo_region_safe_cast(arg);
-    geo_region_free(region);
-}
-
 static void geo_region_polygon_select__(geo_region_type *region,
                                         const geo_polygon_type *polygon,
                                         bool select_inside, bool select) {

--- a/lib/geometry/geo_surface.cpp
+++ b/lib/geometry/geo_surface.cpp
@@ -142,12 +142,6 @@ void geo_surface_fprintf_irap(const geo_surface_type *surface,
     geo_surface_fprintf_irap__(surface, filename, zcoord);
 }
 
-void geo_surface_fprintf_irap_external_zcoord(const geo_surface_type *surface,
-                                              const char *filename,
-                                              const double *zcoord) {
-    geo_surface_fprintf_irap__(surface, filename, zcoord);
-}
-
 geo_surface_type *geo_surface_alloc_new(int nx, int ny, double xinc,
                                         double yinc, double xstart,
                                         double ystart, double angle) {
@@ -310,11 +304,6 @@ geo_surface_type *geo_surface_alloc_copy(const geo_surface_type *src,
 void geo_surface_free(geo_surface_type *surface) {
     geo_pointset_free(surface->pointset);
     free(surface);
-}
-
-void geo_surface_free__(void *arg) {
-    geo_surface_type *surface = geo_surface_safe_cast(arg);
-    geo_surface_free(surface);
 }
 
 geo_pointset_type *geo_surface_get_pointset(const geo_surface_type *surface) {

--- a/lib/include/ert/geometry/geo_polygon.hpp
+++ b/lib/include/ert/geometry/geo_polygon.hpp
@@ -22,8 +22,6 @@ bool geo_polygon_contains_point(const geo_polygon_type *polygon, double x,
 bool geo_polygon_contains_point__(const geo_polygon_type *polygon, double x,
                                   double y, bool force_edge_inside);
 void geo_polygon_reset(geo_polygon_type *polygon);
-void geo_polygon_fprintf(const geo_polygon_type *polygon, FILE *stream);
-void geo_polygon_shift(geo_polygon_type *polygon, double x0, double y0);
 void geo_polygon_close(geo_polygon_type *polygoon);
 int geo_polygon_get_size(const geo_polygon_type *polygon);
 void geo_polygon_iget_xy(const geo_polygon_type *polygon, int index, double *x,

--- a/lib/include/ert/geometry/geo_region.hpp
+++ b/lib/include/ert/geometry/geo_region.hpp
@@ -19,7 +19,6 @@ typedef struct geo_region_struct geo_region_type;
 geo_region_type *geo_region_alloc(const geo_pointset_type *pointset,
                                   bool preselect);
 void geo_region_free(geo_region_type *region);
-void geo_region_free__(void *arg);
 void geo_region_reset(geo_region_type *region);
 const int_vector_type *geo_region_get_index_list(geo_region_type *region);
 

--- a/lib/include/ert/geometry/geo_surface.hpp
+++ b/lib/include/ert/geometry/geo_surface.hpp
@@ -14,7 +14,6 @@ bool geo_surface_equal_header(const geo_surface_type *surface1,
 bool geo_surface_equal(const geo_surface_type *surface1,
                        const geo_surface_type *surface2);
 void geo_surface_free(geo_surface_type *geo_surface);
-void geo_surface_free__(void *arg);
 geo_pointset_type *geo_surface_get_pointset(const geo_surface_type *surface);
 geo_surface_type *geo_surface_fload_alloc_irap(const char *filename,
                                                bool loadz);
@@ -27,9 +26,6 @@ double geo_surface_iget_zvalue(const geo_surface_type *surface, int index);
 int geo_surface_get_size(const geo_surface_type *surface);
 void geo_surface_fprintf_irap(const geo_surface_type *surface,
                               const char *filename);
-void geo_surface_fprintf_irap_external_zcoord(const geo_surface_type *surface,
-                                              const char *filename,
-                                              const double *zcoord);
 int geo_surface_get_nx(const geo_surface_type *surface);
 int geo_surface_get_ny(const geo_surface_type *surface);
 void geo_surface_iget_xy(const geo_surface_type *surface, int index, double *x,

--- a/lib/include/resdata/fault_block.hpp
+++ b/lib/include/resdata/fault_block.hpp
@@ -27,8 +27,6 @@ void fault_block_export_cell(const fault_block_type *fault_block, int index,
 void fault_block_assign_to_region(fault_block_type *fault_block, int region_id);
 const int_vector_type *
 fault_block_get_region_list(const fault_block_type *fault_block);
-int fault_block_iget_j(const fault_block_type *fault_block, int index);
-int fault_block_iget_i(const fault_block_type *fault_block, int index);
 void fault_block_add_cell(fault_block_type *fault_block, int i, int j);
 bool fault_block_trace_edge(const fault_block_type *block,
                             double_vector_type *x_list,

--- a/lib/include/resdata/fault_block_layer.hpp
+++ b/lib/include/resdata/fault_block_layer.hpp
@@ -18,7 +18,6 @@ typedef struct fault_block_layer_struct fault_block_layer_type;
 fault_block_layer_type *fault_block_layer_alloc(const rd_grid_type *grid,
                                                 int k);
 void fault_block_layer_free(fault_block_layer_type *layer);
-void fault_block_layer_free__(void *arg);
 bool fault_block_layer_has_block(const fault_block_layer_type *layer,
                                  int block_id);
 void fault_block_layer_del_block(fault_block_layer_type *layer, int block_id);

--- a/lib/include/resdata/fortio.h
+++ b/lib/include/resdata/fortio.h
@@ -41,11 +41,7 @@ typedef enum {
 
 typedef struct fortio_struct fortio_type;
 
-fortio_status_type fortio_check_buffer(FILE *stream, bool endian_flip,
-                                       size_t buffer_size);
-fortio_status_type fortio_check_file(const char *filename, bool endian_flip);
 bool fortio_looks_like_fortran_file(const char *, bool);
-void fortio_copy_record(fortio_type *, fortio_type *, int, void *, bool *);
 fortio_type *fortio_open_reader(const char *, bool fmt_file,
                                 bool endian_flip_header);
 fortio_type *fortio_open_writer(const char *, bool fmt_file,
@@ -61,14 +57,11 @@ int fortio_init_read(fortio_type *);
 bool fortio_complete_read(fortio_type *, int record_size);
 void fortio_init_write(fortio_type *, int);
 void fortio_complete_write(fortio_type *, int record_size);
-void fortio_fskip_buffer(fortio_type *, int);
 int fortio_fskip_record(fortio_type *);
 bool fortio_fread_buffer(fortio_type *, char *buffer, int buffer_size);
 void fortio_fwrite_record(fortio_type *, const char *buffer, int buffer_size);
 FILE *fortio_get_FILE(const fortio_type *);
 void fortio_fflush(fortio_type *);
-bool fortio_ftruncate_current(fortio_type *fortio);
-bool fortio_is_fortio_file(fortio_type *);
 void fortio_rewind(const fortio_type *fortio);
 const char *fortio_filename_ref(const fortio_type *);
 bool fortio_fmt_file(const fortio_type *);

--- a/lib/include/resdata/layer.hpp
+++ b/lib/include/resdata/layer.hpp
@@ -33,10 +33,7 @@ bool layer_iget_left_barrier(const layer_type *layer, int i, int j);
 bool layer_iget_bottom_barrier(const layer_type *layer, int i, int j);
 int layer_get_nx(const layer_type *layer);
 int layer_get_ny(const layer_type *layer);
-void layer_fprintf_cell(const layer_type *layer, int i, int j, FILE *stream);
 void layer_fprintf(const layer_type *layer, FILE *stream);
-void layer_fprintf_box(const layer_type *layer, FILE *stream, int i1, int i2,
-                       int j1, int j2);
 layer_type *layer_alloc(int nx, int ny);
 void layer_free(layer_type *layer);
 int layer_replace_cell_values(layer_type *layer, int old_value, int new_value);

--- a/lib/include/resdata/rd_kw_grdecl.hpp
+++ b/lib/include/resdata/rd_kw_grdecl.hpp
@@ -17,24 +17,11 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl_dynamic__(FILE *stream, const char *kw,
 rd_kw_type *rd_kw_fscanf_alloc_grdecl_dynamic(FILE *stream, const char *kw,
                                               rd_data_type);
 
-rd_kw_type *rd_kw_fscanf_alloc_grdecl_data__(FILE *stream, bool strict,
-                                             int size, rd_data_type data_type);
-rd_kw_type *rd_kw_fscanf_alloc_grdecl_data(FILE *stream, int size,
-                                           rd_data_type data_type);
-
-rd_kw_type *rd_kw_fscanf_alloc_grdecl__(FILE *stream, const char *kw,
-                                        bool strict, int size,
-                                        rd_data_type data_type);
 rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw, int size,
                                       rd_data_type data_type);
 
-rd_kw_type *rd_kw_fscanf_alloc_current_grdecl__(FILE *stream, bool strict,
-                                                rd_data_type data_type);
 rd_kw_type *rd_kw_fscanf_alloc_current_grdecl(FILE *stream,
                                               rd_data_type data_type);
-
-bool rd_kw_grdecl_fseek_next_kw(FILE *stream);
-char *rd_kw_grdecl_alloc_next_header(FILE *stream);
 
 void rd_kw_fprintf_grdecl(const rd_kw_type *rd_kw, FILE *stream);
 void rd_kw_fprintf_grdecl__(const rd_kw_type *rd_kw, const char *special_header,

--- a/lib/include/resdata/rd_rft_node.hpp
+++ b/lib/include/resdata/rd_rft_node.hpp
@@ -17,18 +17,14 @@ typedef enum {
 
 typedef struct rd_rft_node_struct rd_rft_node_type;
 
-void rd_rft_node_inplace_sort_cells(rd_rft_node_type *rft_node);
 const rd_rft_cell_type *rd_rft_node_iget_cell_sorted(rd_rft_node_type *rft_node,
                                                      int index);
 const rd_rft_cell_type *rd_rft_node_iget_cell(const rd_rft_node_type *rft_node,
                                               int index);
 const rd_rft_cell_type *rd_rft_node_lookup_ijk(const rd_rft_node_type *rft_node,
                                                int i, int j, int k);
-void rd_rft_node_fprintf_rft_obs(const rd_rft_node_type *, double, const char *,
-                                 const char *, double);
 rd_rft_node_type *rd_rft_node_alloc(const rd_file_view_type *rft_view);
 void rd_rft_node_free(rd_rft_node_type *);
-void rd_rft_node_free__(void *);
 time_t rd_rft_node_get_date(const rd_rft_node_type *);
 int rd_rft_node_get_size(const rd_rft_node_type *);
 const char *rd_rft_node_get_well_name(const rd_rft_node_type *rft_node);
@@ -52,11 +48,8 @@ double rd_rft_node_iget_soil(const rd_rft_node_type *rft_node, int index);
 void rd_rft_node_fwrite(const rd_rft_node_type *rft_node, fortio_type *fortio,
                         ert_rd_unit_enum unit_set);
 double rd_rft_node_get_days(const rd_rft_node_type *rft_node);
-int rd_rft_node_cmp(const rd_rft_node_type *n1, const rd_rft_node_type *n2);
 bool rd_rft_node_lt(const rd_rft_node_type *n1, const rd_rft_node_type *n2);
 
-void rd_rft_node_append_cell(rd_rft_node_type *rft_node,
-                             rd_rft_cell_type *cell);
 rd_rft_node_type *rd_rft_node_alloc_new(const char *well_name,
                                         const char *data_type_string,
                                         const time_t recording_date,

--- a/lib/include/resdata/rd_smspec.hpp
+++ b/lib/include/resdata/rd_smspec.hpp
@@ -16,25 +16,6 @@ typedef struct rd_smspec_struct rd_smspec_type;
 #include <vector>
 const std::vector<float> &
 rd_smspec_get_params_default(const rd_smspec_type *rd_smspec);
-const rd::smspec_node &rd_smspec_get_well_var_node(const rd_smspec_type *smspec,
-                                                   const char *well,
-                                                   const char *var);
-const rd::smspec_node &
-rd_smspec_get_group_var_node(const rd_smspec_type *smspec, const char *group,
-                             const char *var);
-const rd::smspec_node &
-rd_smspec_get_field_var_node(const rd_smspec_type *smspec, const char *var);
-const rd::smspec_node &
-rd_smspec_get_region_var_node(const rd_smspec_type *rd_smspec,
-                              const char *region_var, int region_nr);
-const rd::smspec_node &
-rd_smspec_get_misc_var_node(const rd_smspec_type *rd_smspec, const char *var);
-const rd::smspec_node &
-rd_smspec_get_block_var_node(const rd_smspec_type *rd_smspec,
-                             const char *block_var, int block_nr);
-const rd::smspec_node &
-rd_smspec_get_block_var_node_ijk(const rd_smspec_type *rd_smspec,
-                                 const char *block_var, int i, int j, int k);
 const rd::smspec_node &
 rd_smspec_get_well_completion_var_node(const rd_smspec_type *rd_smspec,
                                        const char *well, const char *var,
@@ -68,15 +49,7 @@ extern "C" {
 int *rd_smspec_alloc_mapping(const rd_smspec_type *self,
                              const rd_smspec_type *other);
 const int *rd_smspec_get_index_map(const rd_smspec_type *smspec);
-rd_smspec_var_type rd_smspec_iget_var_type(const rd_smspec_type *smspec,
-                                           int index);
-bool rd_smspec_needs_num(rd_smspec_var_type var_type);
-bool rd_smspec_needs_wgname(rd_smspec_var_type var_type);
-const char *rd_smspec_get_var_type_name(rd_smspec_var_type var_type);
 rd_smspec_var_type rd_smspec_identify_var_type(const char *var);
-rd_smspec_type *rd_smspec_alloc_empty(bool write_mode,
-                                      const char *key_join_string);
-
 rd_smspec_type *rd_smspec_alloc_restart_writer(
     const char *key_join_string, const char *restart_case, int restart_step,
     time_t sim_start, bool time_in_days, int nx, int ny, int nz);
@@ -98,53 +71,13 @@ int rd_smspec_get_date_year_index(const rd_smspec_type *smspec);
 
 int rd_smspec_get_well_var_params_index(const rd_smspec_type *rd_smspec,
                                         const char *well, const char *var);
-bool rd_smspec_has_well_var(const rd_smspec_type *rd_smspec, const char *well,
-                            const char *var);
-
-int rd_smspec_get_group_var_params_index(const rd_smspec_type *rd_smspec,
-                                         const char *group, const char *var);
-bool rd_smspec_has_group_var(const rd_smspec_type *rd_smspec, const char *group,
-                             const char *var);
-
-int rd_smspec_get_field_var_params_index(const rd_smspec_type *rd_smspec,
-                                         const char *var);
-bool rd_smspec_has_field_var(const rd_smspec_type *rd_smspec, const char *var);
-
-int rd_smspec_get_region_var_params_index(const rd_smspec_type *rd_smspec,
-                                          const char *region_var,
-                                          int region_nr);
-bool rd_smspec_has_region_var(const rd_smspec_type *rd_smspec,
-                              const char *region_var, int region_nr);
-
-int rd_smspec_get_misc_var_params_index(const rd_smspec_type *rd_smspec,
-                                        const char *var);
-bool rd_smspec_has_misc_var(const rd_smspec_type *rd_smspec, const char *var);
-
-int rd_smspec_get_block_var_params_index(const rd_smspec_type *rd_smspec,
-                                         const char *block_var, int block_nr);
-bool rd_smspec_has_block_var(const rd_smspec_type *rd_smspec,
-                             const char *block_var, int block_nr);
-
-int rd_smspec_get_block_var_params_index_ijk(const rd_smspec_type *rd_smspec,
-                                             const char *block_var, int i,
-                                             int j, int k);
-bool rd_smspec_has_block_var_ijk(const rd_smspec_type *rd_smspec,
-                                 const char *block_var, int i, int j, int k);
-
 int rd_smspec_get_well_completion_var_params_index(
     const rd_smspec_type *rd_smspec, const char *well, const char *var,
     int cell_nr);
-bool rd_smspec_has_well_completion_var(const rd_smspec_type *rd_smspec,
-                                       const char *well, const char *var,
-                                       int cell_nr);
-
 int rd_smspec_get_general_var_params_index(const rd_smspec_type *rd_smspec,
                                            const char *lookup_kw);
 bool rd_smspec_has_general_var(const rd_smspec_type *rd_smspec,
                                const char *lookup_kw);
-const char *rd_smspec_get_general_var_unit(const rd_smspec_type *rd_smspec,
-                                           const char *lookup_kw);
-
 void rd_smspec_select_matching_general_var_list(const rd_smspec_type *smspec,
                                                 const char *pattern,
                                                 stringlist_type *keys);
@@ -161,22 +94,13 @@ stringlist_type *rd_smspec_alloc_well_list(const rd_smspec_type *smspec,
                                            const char *pattern);
 stringlist_type *rd_smspec_alloc_group_list(const rd_smspec_type *smspec,
                                             const char *pattern);
-stringlist_type *rd_smspec_alloc_well_var_list(const rd_smspec_type *smspec);
-const char *rd_smspec_get_simulation_path(const rd_smspec_type *rd_smspec);
 int rd_smspec_get_first_step(const rd_smspec_type *rd_smspec);
 int rd_smspec_get_restart_step(const rd_smspec_type *rd_smspec);
 const char *rd_smspec_get_restart_case(const rd_smspec_type *rd_smspec);
-const char *rd_smspec_get_join_string(const rd_smspec_type *smspec);
-
 const int *rd_smspec_get_grid_dims(const rd_smspec_type *smspec);
 int rd_smspec_get_params_size(const rd_smspec_type *smspec);
 int rd_smspec_num_nodes(const rd_smspec_type *smspec);
-
-char *rd_smspec_alloc_well_key(const rd_smspec_type *smspec,
-                               const char *keyword, const char *wgname);
 bool rd_smspec_equal(const rd_smspec_type *self, const rd_smspec_type *other);
-
-// void                       rd_smspec_sort( rd_smspec_type * smspec );
 ert_rd_unit_enum rd_smspec_get_unit_system(const rd_smspec_type *smspec);
 
 #ifdef __cplusplus

--- a/lib/include/resdata/rd_sum_data.hpp
+++ b/lib/include/resdata/rd_sum_data.hpp
@@ -19,11 +19,8 @@ extern "C" {
 
 typedef struct rd_sum_data_struct rd_sum_data_type;
 
-void rd_sum_data_reset_self_map(rd_sum_data_type *data);
 void rd_sum_data_add_case(rd_sum_data_type *self,
                           const rd_sum_data_type *other);
-void rd_sum_data_fwrite_step(const rd_sum_data_type *data, const char *rd_case,
-                             bool fmt_case, bool unified, int report_step);
 void rd_sum_data_fwrite(const rd_sum_data_type *data, const char *rd_case,
                         bool fmt_case, bool unified);
 bool rd_sum_data_can_write(const rd_sum_data_type *data);
@@ -38,23 +35,17 @@ int rd_sum_data_get_report_step_from_days(const rd_sum_data_type *data,
                                           double days);
 bool rd_sum_data_check_sim_time(const rd_sum_data_type *data, time_t sim_time);
 bool rd_sum_data_check_sim_days(const rd_sum_data_type *data, double sim_days);
-int rd_sum_data_get_num_ministep(const rd_sum_data_type *data);
 double_vector_type *rd_sum_data_alloc_data_vector(const rd_sum_data_type *data,
                                                   int data_index,
                                                   bool report_only);
-void rd_sum_data_init_time_vector(const rd_sum_data_type *data,
-                                  time_t_vector_type *time_vector,
-                                  bool report_only);
 time_t_vector_type *rd_sum_data_alloc_time_vector(const rd_sum_data_type *data,
                                                   bool report_only);
 time_t rd_sum_data_get_data_start(const rd_sum_data_type *data);
 time_t rd_sum_data_get_report_time(const rd_sum_data_type *data,
                                    int report_step);
 double rd_sum_data_get_first_day(const rd_sum_data_type *data);
-time_t rd_sum_data_get_sim_start(const rd_sum_data_type *data);
 time_t rd_sum_data_get_sim_end(const rd_sum_data_type *data);
 double rd_sum_data_get_sim_length(const rd_sum_data_type *data);
-void rd_sum_data_summarize(const rd_sum_data_type *data, FILE *stream);
 double rd_sum_data_iget(const rd_sum_data_type *data, int internal_index,
                         int params_index);
 
@@ -67,9 +58,6 @@ void rd_sum_data_get_interp_vector(const rd_sum_data_type *data,
 
 bool rd_sum_data_has_report_step(const rd_sum_data_type *, int);
 
-rd_sum_data_type *rd_sum_data_fread_alloc(rd_smspec_type *,
-                                          const stringlist_type *filelist,
-                                          bool include_restart, bool lazy_load);
 void rd_sum_data_free(rd_sum_data_type *);
 int rd_sum_data_get_last_report_step(const rd_sum_data_type *data);
 int rd_sum_data_get_first_report_step(const rd_sum_data_type *data);
@@ -90,14 +78,10 @@ rd_sum_tstep_type *rd_sum_data_add_new_tstep(rd_sum_data_type *data,
                                              double sim_seconds);
 bool rd_sum_data_report_step_equal(const rd_sum_data_type *data1,
                                    const rd_sum_data_type *data2);
-bool rd_sum_data_report_step_compatible(const rd_sum_data_type *data1,
-                                        const rd_sum_data_type *data2);
 void rd_sum_data_fwrite_interp_csv_line(const rd_sum_data_type *data,
                                         time_t sim_time,
                                         const rd_sum_vector_type *keylist,
                                         FILE *fp);
-double rd_sum_data_get_last_value(const rd_sum_data_type *data,
-                                  int param_index);
 double rd_sum_data_iget_last_value(const rd_sum_data_type *data,
                                    int param_index);
 double rd_sum_data_iget_first_value(const rd_sum_data_type *data,

--- a/lib/include/resdata/rd_type.hpp
+++ b/lib/include/resdata/rd_type.hpp
@@ -124,9 +124,6 @@ bool rd_type_is_mess(const rd_data_type);
 bool rd_type_is_bool(const rd_data_type);
 bool rd_type_is_string(const rd_data_type);
 
-// Temporary fixup for OPM.
-char *rd_type_get_name(const rd_data_type);
-
 #ifdef __cplusplus
 }
 #endif

--- a/lib/include/resdata/well/well_rseg_loader.hpp
+++ b/lib/include/resdata/well/well_rseg_loader.hpp
@@ -12,8 +12,6 @@ typedef struct well_rseg_loader_struct well_rseg_loader_type;
 well_rseg_loader_type *well_rseg_loader_alloc(rd_file_view_type *rst_view);
 void well_rseg_loader_free(well_rseg_loader_type *well_rseg_loader);
 
-int well_rseg_loader_element_count(
-    const well_rseg_loader_type *well_rseg_loader);
 double *
 well_rseg_loader_load_values(const well_rseg_loader_type *well_rseg_loader,
                              int rseg_offset);

--- a/lib/resdata/fault_block.cpp
+++ b/lib/resdata/fault_block.cpp
@@ -144,11 +144,11 @@ void fault_block_export_cell(const fault_block_type *fault_block, int index,
     rd_grid_get_xyz3(fault_block->grid, *i, *j, *k, x, y, z);
 }
 
-int fault_block_iget_i(const fault_block_type *fault_block, int index) {
+static int fault_block_iget_i(const fault_block_type *fault_block, int index) {
     return int_vector_iget(fault_block->i_list, index);
 }
 
-int fault_block_iget_j(const fault_block_type *fault_block, int index) {
+static int fault_block_iget_j(const fault_block_type *fault_block, int index) {
     return int_vector_iget(fault_block->j_list, index);
 }
 

--- a/lib/resdata/fault_block_layer.cpp
+++ b/lib/resdata/fault_block_layer.cpp
@@ -270,11 +270,6 @@ void fault_block_layer_free(fault_block_layer_type *layer) {
     free(layer);
 }
 
-void fault_block_layer_free__(void *arg) {
-    fault_block_layer_type *layer = fault_block_layer_safe_cast(arg);
-    fault_block_layer_free(layer);
-}
-
 void fault_block_layer_insert_block_content(fault_block_layer_type *layer,
                                             const fault_block_type *src_block) {
     int next_block_id = fault_block_layer_get_next_id(layer);

--- a/lib/resdata/layer.cpp
+++ b/lib/resdata/layer.cpp
@@ -374,8 +374,8 @@ static void layer_fprintf_header(const layer_type *layer, FILE *stream, int i1,
     fprintf(stream, "\n");
 }
 
-void layer_fprintf_box(const layer_type *layer, FILE *stream, int i1, int i2,
-                       int j1, int j2) {
+static void layer_fprintf_box(const layer_type *layer, FILE *stream, int i1,
+                              int i2, int j1, int j2) {
     int i, j;
     layer_fprintf_header(layer, stream, i1, i2);
     layer_fprintf_dash(layer, stream, i1, i2);
@@ -396,19 +396,6 @@ void layer_fprintf_box(const layer_type *layer, FILE *stream, int i1, int i2,
 
 void layer_fprintf(const layer_type *layer, FILE *stream) {
     layer_fprintf_box(layer, stream, 0, layer->nx - 1, 0, layer->ny - 1);
-}
-
-void layer_fprintf_cell(const layer_type *layer, int i, int j, FILE *stream) {
-    int g = layer_get_global_cell_index(layer, i, j);
-    cell_type *cell = &layer->data[g];
-
-    fprintf(stream, " i:%d   j:%d  \n", i, j);
-    fprintf(stream, "       *--- %4d ---* \n", cell->edges[TOP_EDGE]);
-    fprintf(stream, "       |            | \n");
-    fprintf(stream, "     %4d   %4d %4d\n", cell->edges[LEFT_EDGE],
-            cell->cell_value, cell->edges[RIGHT_EDGE]);
-    fprintf(stream, "       |            | \n");
-    fprintf(stream, "       *--- %4d ---* \n", cell->edges[BOTTOM_EDGE]);
 }
 
 static bool layer_find_edge(const layer_type *layer, int *i, int *j,

--- a/lib/resdata/rd_kw_grdecl.cpp
+++ b/lib/resdata/rd_kw_grdecl.cpp
@@ -52,7 +52,7 @@
   are ignored.
 */
 
-bool rd_kw_grdecl_fseek_next_kw(FILE *stream) {
+static bool rd_kw_grdecl_fseek_next_kw(FILE *stream) {
     long start_pos = util_ftell(stream);
     long current_pos;
     char next_kw[MAX_GRDECL_HEADER_SIZE];
@@ -114,22 +114,6 @@ bool rd_kw_grdecl_fseek_next_kw(FILE *stream) {
             return false;
         }
     }
-}
-
-/**
-   Will use the rd_kw_grdecl_fseek_next_header() to seek out the next
-   header string, and read and return that string. If no more headers
-   are found the function will return NULL. The storage allocated by
-   this function must be free'd by the calling scope.
-*/
-
-char *rd_kw_grdecl_alloc_next_header(FILE *stream) {
-    if (rd_kw_grdecl_fseek_next_kw(stream)) {
-        char next_kw[MAX_GRDECL_HEADER_SIZE];
-        fscanf(stream, "%s", next_kw);
-        return util_alloc_string_copy(next_kw);
-    } else
-        return NULL;
 }
 
 /**
@@ -455,24 +439,6 @@ static rd_kw_type *__rd_kw_fscanf_alloc_grdecl__(FILE *stream,
     }
 }
 
-/**
-   This function assumes that the file pointer has already been
-   positioned at the beginning of a keyword header, and will just
-   start reading a header string right away; if the file pointer is
-   incorrectly positioned this will most probably blow up big time.
-*/
-
-rd_kw_type *rd_kw_fscanf_alloc_grdecl_data__(FILE *stream, bool strict,
-                                             int size, rd_data_type data_type) {
-    return __rd_kw_fscanf_alloc_grdecl__(stream, NULL, strict, size, data_type);
-}
-
-rd_kw_type *rd_kw_fscanf_alloc_grdecl_data(FILE *stream, int size,
-                                           rd_data_type data_type) {
-    bool strict = true;
-    return rd_kw_fscanf_alloc_grdecl_data__(stream, strict, size, data_type);
-}
-
 /*
    This function will seek through the file and position the file
    pointer at the beginning of @kw before starting to load (this
@@ -508,9 +474,9 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl_dynamic(FILE *stream, const char *kw,
    size == 0.
 */
 
-rd_kw_type *rd_kw_fscanf_alloc_grdecl__(FILE *stream, const char *kw,
-                                        bool strict, int size,
-                                        rd_data_type data_type) {
+static rd_kw_type *rd_kw_fscanf_alloc_grdecl__(FILE *stream, const char *kw,
+                                               bool strict, int size,
+                                               rd_data_type data_type) {
     return __rd_kw_fscanf_alloc_grdecl__(stream, kw, strict, size, data_type);
 }
 
@@ -528,8 +494,9 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw, int size,
    that the input file is well formatted.
 */
 
-rd_kw_type *rd_kw_fscanf_alloc_current_grdecl__(FILE *stream, bool strict,
-                                                rd_data_type data_type) {
+static rd_kw_type *rd_kw_fscanf_alloc_current_grdecl__(FILE *stream,
+                                                       bool strict,
+                                                       rd_data_type data_type) {
     return __rd_kw_fscanf_alloc_grdecl__(stream, NULL, strict, 0, data_type);
 }
 

--- a/lib/resdata/rd_rft_node.cpp
+++ b/lib/resdata/rd_rft_node.cpp
@@ -123,8 +123,8 @@ static rd_rft_node_type *rd_rft_node_alloc_empty(const char *data_type_string) {
 UTIL_SAFE_CAST_FUNCTION(rd_rft_node, RD_RFT_NODE_ID);
 UTIL_IS_INSTANCE_FUNCTION(rd_rft_node, RD_RFT_NODE_ID);
 
-void rd_rft_node_append_cell(rd_rft_node_type *rft_node,
-                             rd_rft_cell_type *cell) {
+static void rd_rft_node_append_cell(rd_rft_node_type *rft_node,
+                                    rd_rft_cell_type *cell) {
     if (rft_node->MSW) {
         auto pos_iter =
             std::upper_bound(rft_node->cells.begin(), rft_node->cells.end(),
@@ -307,10 +307,6 @@ void rd_rft_node_free(rd_rft_node_type *rft_node) {
         rd_rft_cell_free(cell_ptr);
 
     delete rft_node;
-}
-
-void rd_rft_node_free__(void *void_node) {
-    rd_rft_node_free(rd_rft_node_safe_cast(void_node));
 }
 
 int rd_rft_node_get_size(const rd_rft_node_type *rft_node) {
@@ -591,7 +587,8 @@ void rd_rft_node_fwrite(const rd_rft_node_type *rft_node, fortio_type *fortio,
     }
 }
 
-int rd_rft_node_cmp(const rd_rft_node_type *n1, const rd_rft_node_type *n2) {
+static int rd_rft_node_cmp(const rd_rft_node_type *n1,
+                           const rd_rft_node_type *n2) {
     time_t val1 = rd_rft_node_get_date(n1);
     time_t val2 = rd_rft_node_get_date(n2);
 

--- a/lib/resdata/rd_smspec.cpp
+++ b/lib/resdata/rd_smspec.cpp
@@ -259,8 +259,8 @@ int rd_smspec_get_params_size(const rd_smspec_type *smspec) {
     return smspec->params_size;
 }
 
-rd_smspec_type *rd_smspec_alloc_empty(bool write_mode,
-                                      const char *key_join_string) {
+static rd_smspec_type *rd_smspec_alloc_empty(bool write_mode,
+                                             const char *key_join_string) {
     rd_smspec_type *rd_smspec = new rd_smspec_type();
     UTIL_TYPE_ID_INIT(rd_smspec, RD_SMSPEC_ID);
 
@@ -593,76 +593,6 @@ static bool rd_smspec_lgr_var_type(rd_smspec_var_type var_type) {
 }
 
 /**
-   Takes a rd_smspec_var_type variable as input, and return a string
-   representation of this var_type. Suitable for debug messages +++
-*/
-
-const char *rd_smspec_get_var_type_name(rd_smspec_var_type var_type) {
-    switch (var_type) {
-    case (RD_SMSPEC_INVALID_VAR):
-        return "INVALID_VAR";
-        break;
-    case (RD_SMSPEC_AQUIFER_VAR):
-        return "AQUIFER_VAR";
-        break;
-    case (RD_SMSPEC_WELL_VAR):
-        return "WELL_VAR";
-        break;
-    case (RD_SMSPEC_REGION_VAR):
-        return "REGION_VAR";
-        break;
-    case (RD_SMSPEC_FIELD_VAR):
-        return "FIELD_VAR";
-        break;
-    case (RD_SMSPEC_GROUP_VAR):
-        return "GROUP_VAR";
-        break;
-    case (RD_SMSPEC_BLOCK_VAR):
-        return "BLOCK_VAR";
-        break;
-    case (RD_SMSPEC_COMPLETION_VAR):
-        return "COMPLETION_VAR";
-        break;
-    case (RD_SMSPEC_LOCAL_BLOCK_VAR):
-        return "LOCAL_BLOCK_VAR";
-        break;
-    case (RD_SMSPEC_LOCAL_COMPLETION_VAR):
-        return "LOCAL_COMPLETION_VAR";
-        break;
-    case (RD_SMSPEC_LOCAL_WELL_VAR):
-        return "LOCAL_WELL_VAR";
-        break;
-    case (RD_SMSPEC_NETWORK_VAR):
-        return "NETWORK_VAR";
-        break;
-    case (RD_SMSPEC_REGION_2_REGION_VAR):
-        return "REGION_2_REGION_VAR";
-        break;
-    case (RD_SMSPEC_SEGMENT_VAR):
-        return "SEGMENT_VAR";
-        break;
-    case (RD_SMSPEC_MISC_VAR):
-        return "MISC_VAR";
-        break;
-    default:
-        util_abort("%s: Unrecognized variable type:%d \n", __func__, var_type);
-        return NULL;
-    }
-}
-
-/**
-  Input i,j,k are assumed to be in the interval [1..nx] , [1..ny],
-  [1..nz], return value is a global index which can be used in the
-  xxx_block_xxx routines.
-*/
-
-static int rd_smspec_get_global_grid_index(const rd_smspec_type *smspec, int i,
-                                           int j, int k) {
-    return i + (j - 1) * smspec->grid_dims[0] +
-           (k - 1) * smspec->grid_dims[0] * smspec->grid_dims[1];
-}
-
-/**
    This function takes a fully initialized smspec_node instance, generates the
    corresponding key and inserts smspec_node instance in the main hash table
    smspec->gen_var_index.
@@ -751,91 +681,6 @@ static void rd_smspec_install_special_keys(rd_smspec_type *rd_smspec,
     default:
         throw std::invalid_argument("Internal error - should not be here \n");
     }
-}
-
-/**
-   The usage of this functon breaks down completely if LGR's are involved.
-*/
-
-bool rd_smspec_needs_wgname(rd_smspec_var_type var_type) {
-    switch (var_type) {
-    case (RD_SMSPEC_COMPLETION_VAR):
-        return true;
-        break;
-    case (RD_SMSPEC_FIELD_VAR):
-        return false;
-        break;
-    case (RD_SMSPEC_GROUP_VAR):
-        return true;
-        break;
-    case (RD_SMSPEC_WELL_VAR):
-        return true;
-        break;
-    case (RD_SMSPEC_REGION_VAR):
-        return false;
-        break;
-    case (RD_SMSPEC_REGION_2_REGION_VAR):
-        return false;
-        break;
-    case (RD_SMSPEC_MISC_VAR):
-        return false;
-        break;
-    case (RD_SMSPEC_BLOCK_VAR):
-        return false;
-        break;
-    case (RD_SMSPEC_AQUIFER_VAR):
-        return false;
-        break;
-    case (RD_SMSPEC_SEGMENT_VAR):
-        return true;
-        break;
-    default:
-        util_exit("Sorry: support for variables of type:%s is not implemented "
-                  "in %s.\n",
-                  rd_smspec_get_var_type_name(var_type), __FILE__);
-    }
-    /* Really should not be here. */
-    return false;
-}
-
-/**
-   The usage of this functon breaks down completely if LGR's are involved.
-*/
-bool rd_smspec_needs_num(rd_smspec_var_type var_type) {
-    switch (var_type) {
-    case (RD_SMSPEC_COMPLETION_VAR):
-        return true;
-        break;
-    case (RD_SMSPEC_AQUIFER_VAR):
-        return true;
-        break;
-    case (RD_SMSPEC_FIELD_VAR):
-        return false;
-        break;
-    case (RD_SMSPEC_GROUP_VAR):
-        return false;
-        break;
-    case (RD_SMSPEC_WELL_VAR):
-        return false;
-        break;
-    case (RD_SMSPEC_REGION_VAR):
-        return true;
-        break;
-    case (RD_SMSPEC_REGION_2_REGION_VAR):
-        return true;
-        break;
-    case (RD_SMSPEC_MISC_VAR):
-        return false;
-        break;
-    case (RD_SMSPEC_BLOCK_VAR):
-        return true;
-        break;
-    default:
-        util_exit("Sorry: support for variables of type:%s is not implemented "
-                  "in %s.\n",
-                  rd_smspec_get_var_type_name(var_type), __FILE__);
-    }
-    return false;
 }
 
 bool rd_smspec_equal(const rd_smspec_type *self, const rd_smspec_type *other) {
@@ -1262,18 +1107,6 @@ rd_smspec_type *rd_smspec_fread_alloc(const char *header_file,
     }
 }
 
-int rd_smspec_get_num_groups(const rd_smspec_type *rd_smspec) {
-    return rd_smspec->group_var_index.size();
-}
-
-/*char ** rd_smspec_alloc_group_names(const rd_smspec_type * rd_smspec) {
-  return hash_alloc_keylist(rd_smspec->group_var_index);
-}*/
-
-int rd_smspec_get_num_regions(const rd_smspec_type *rd_smspec) {
-    return rd_smspec->num_regions;
-}
-
 /*
    For each type of summary data (according to the types in
    rd_smcspec_var_type there are a set accessor functions:
@@ -1314,19 +1147,6 @@ int node_valid_index(const rd::smspec_node *node_ptr) {
 
 } // namespace
 
-const rd::smspec_node &rd_smspec_get_well_var_node(const rd_smspec_type *smspec,
-                                                   const char *well,
-                                                   const char *var) {
-    const auto node_ptr =
-        rd_smspec_get_str_key_var_node(smspec->well_var_index, well, var);
-    if (!node_ptr)
-        throw std::out_of_range("The well: " + std::string(well) +
-                                " variable: " + std::string(var) +
-                                " combination does not exist.");
-
-    return *node_ptr;
-}
-
 int rd_smspec_get_well_var_params_index(const rd_smspec_type *rd_smspec,
                                         const char *well, const char *var) {
     const auto node_ptr =
@@ -1334,174 +1154,7 @@ int rd_smspec_get_well_var_params_index(const rd_smspec_type *rd_smspec,
     return node_valid_index(node_ptr);
 }
 
-bool rd_smspec_has_well_var(const rd_smspec_type *rd_smspec, const char *well,
-                            const char *var) {
-    const auto node_ptr =
-        rd_smspec_get_str_key_var_node(rd_smspec->well_var_index, well, var);
-    return node_exists(node_ptr);
-}
-
-const rd::smspec_node &
-rd_smspec_get_group_var_node(const rd_smspec_type *smspec, const char *group,
-                             const char *var) {
-    const auto node_ptr =
-        rd_smspec_get_str_key_var_node(smspec->group_var_index, group, var);
-    if (!node_ptr)
-        throw std::out_of_range("The group: " + std::string(group) +
-                                " variable: " + std::string(var) +
-                                " combination does not exist.");
-
-    return *node_ptr;
-}
-
-int rd_smspec_get_group_var_params_index(const rd_smspec_type *rd_smspec,
-                                         const char *group, const char *var) {
-    const auto node_ptr =
-        rd_smspec_get_str_key_var_node(rd_smspec->group_var_index, group, var);
-    return node_valid_index(node_ptr);
-}
-
-bool rd_smspec_has_group_var(const rd_smspec_type *rd_smspec, const char *group,
-                             const char *var) {
-    const auto node_ptr =
-        rd_smspec_get_str_key_var_node(rd_smspec->group_var_index, group, var);
-    return node_exists(node_ptr);
-}
-
-const rd::smspec_node &
-rd_smspec_get_field_var_node(const rd_smspec_type *rd_smspec, const char *var) {
-    const auto node_ptr =
-        rd_smspec_get_var_node(rd_smspec->field_var_index, var);
-    if (!node_ptr)
-        throw std::out_of_range("The field variable: " + std::string(var) +
-                                " does not exist.");
-
-    return *node_ptr;
-}
-
-int rd_smspec_get_field_var_params_index(const rd_smspec_type *rd_smspec,
-                                         const char *var) {
-    const auto node_ptr =
-        rd_smspec_get_var_node(rd_smspec->field_var_index, var);
-    return node_valid_index(node_ptr);
-}
-
-bool rd_smspec_has_field_var(const rd_smspec_type *rd_smspec, const char *var) {
-    const auto node_ptr =
-        rd_smspec_get_var_node(rd_smspec->field_var_index, var);
-    return node_exists(node_ptr);
-}
-
-/**
-   Observe that block_nr is represented as char literal,
-   i.e. "2345". This is because it will be used as a hash key.
-
-   This is the final low level function which actually consults the
-   hash tables.
-*/
-
-const rd::smspec_node &
-rd_smspec_get_block_var_node(const rd_smspec_type *rd_smspec,
-                             const char *block_var, int block_nr) {
-    const auto node_ptr = rd_smspec_get_int_key_var_node(
-        rd_smspec->block_var_index, block_nr, block_var);
-    if (!node_ptr)
-        throw std::out_of_range("No such block variable");
-
-    return *node_ptr;
-}
-
-const rd::smspec_node &
-rd_smspec_get_block_var_node_ijk(const rd_smspec_type *rd_smspec,
-                                 const char *block_var, int i, int j, int k) {
-    return rd_smspec_get_block_var_node(
-        rd_smspec, block_var,
-        rd_smspec_get_global_grid_index(rd_smspec, i, j, k));
-}
-
-bool rd_smspec_has_block_var(const rd_smspec_type *rd_smspec,
-                             const char *block_var, int block_nr) {
-    const auto node_ptr = rd_smspec_get_int_key_var_node(
-        rd_smspec->block_var_index, block_nr, block_var);
-    return node_exists(node_ptr);
-}
-
-bool rd_smspec_has_block_var_ijk(const rd_smspec_type *rd_smspec,
-                                 const char *block_var, int i, int j, int k) {
-    return rd_smspec_has_block_var(
-        rd_smspec, block_var,
-        rd_smspec_get_global_grid_index(rd_smspec, i, j, k));
-}
-
-int rd_smspec_get_block_var_params_index(const rd_smspec_type *rd_smspec,
-                                         const char *block_var, int block_nr) {
-    const auto node_ptr = rd_smspec_get_int_key_var_node(
-        rd_smspec->block_var_index, block_nr, block_var);
-    return node_valid_index(node_ptr);
-}
-
-int rd_smspec_get_block_var_params_index_ijk(const rd_smspec_type *rd_smspec,
-                                             const char *block_var, int i,
-                                             int j, int k) {
-    return rd_smspec_get_block_var_params_index(
-        rd_smspec, block_var,
-        rd_smspec_get_global_grid_index(rd_smspec, i, j, k));
-}
-
-/**
-   region_nr: [1...num_regions] (NOT C-based indexing)
-*/
-
-const rd::smspec_node &
-rd_smspec_get_region_var_node(const rd_smspec_type *rd_smspec,
-                              const char *region_var, int region_nr) {
-    const auto node_ptr = rd_smspec_get_int_key_var_node(
-        rd_smspec->region_var_index, region_nr, region_var);
-    if (!node_ptr)
-        throw std::out_of_range("No such block variable");
-
-    return *node_ptr;
-}
-
-bool rd_smspec_has_region_var(const rd_smspec_type *rd_smspec,
-                              const char *region_var, int region_nr) {
-    const auto node_ptr = rd_smspec_get_int_key_var_node(
-        rd_smspec->region_var_index, region_nr, region_var);
-    return node_exists(node_ptr);
-}
-
-int rd_smspec_get_region_var_params_index(const rd_smspec_type *rd_smspec,
-                                          const char *region_var,
-                                          int region_nr) {
-    const auto node_ptr = rd_smspec_get_int_key_var_node(
-        rd_smspec->region_var_index, region_nr, region_var);
-    return node_valid_index(node_ptr);
-}
-
-const rd::smspec_node &
-rd_smspec_get_misc_var_node(const rd_smspec_type *rd_smspec, const char *var) {
-    const auto node_ptr =
-        rd_smspec_get_var_node(rd_smspec->misc_var_index, var);
-    if (!node_ptr)
-        throw std::out_of_range("No such misc variable");
-
-    return *node_ptr;
-}
-
-bool rd_smspec_has_misc_var(const rd_smspec_type *rd_smspec, const char *var) {
-    const auto node_ptr =
-        rd_smspec_get_var_node(rd_smspec->misc_var_index, var);
-    return node_exists(node_ptr);
-}
-
-int rd_smspec_get_misc_var_params_index(const rd_smspec_type *rd_smspec,
-                                        const char *var) {
-    const auto node_ptr =
-        rd_smspec_get_var_node(rd_smspec->misc_var_index, var);
-    return node_valid_index(node_ptr);
-}
-
-const rd::smspec_node *
+static const rd::smspec_node *
 rd_smspec_get_well_completion_var_node__(const rd_smspec_type *rd_smspec,
                                          const char *well, const char *var,
                                          int cell_nr) {
@@ -1511,26 +1164,6 @@ rd_smspec_get_well_completion_var_node__(const rd_smspec_type *rd_smspec,
 
     const auto &num_map = well_iter->second;
     return rd_smspec_get_int_key_var_node(num_map, cell_nr, var);
-}
-
-const rd::smspec_node &
-rd_smspec_get_well_completion_var_node(const rd_smspec_type *rd_smspec,
-                                       const char *well, const char *var,
-                                       int cell_nr) {
-    const auto node_ptr =
-        rd_smspec_get_well_completion_var_node__(rd_smspec, well, var, cell_nr);
-    if (!node_ptr)
-        throw std::out_of_range("No such well/var/completion");
-
-    return *node_ptr;
-}
-
-bool rd_smspec_has_well_completion_var(const rd_smspec_type *rd_smspec,
-                                       const char *well, const char *var,
-                                       int cell_nr) {
-    const auto node_ptr =
-        rd_smspec_get_well_completion_var_node__(rd_smspec, well, var, cell_nr);
-    return node_exists(node_ptr);
 }
 
 int rd_smspec_get_well_completion_var_params_index(
@@ -1568,14 +1201,6 @@ bool rd_smspec_has_general_var(const rd_smspec_type *rd_smspec,
     const auto node_ptr =
         rd_smspec_get_var_node(rd_smspec->gen_var_index, lookup_kw);
     return node_exists(node_ptr);
-}
-
-/** DIES if the lookup_kw is not present. */
-const char *rd_smspec_get_general_var_unit(const rd_smspec_type *rd_smspec,
-                                           const char *lookup_kw) {
-    const auto smspec_node =
-        rd_smspec_get_general_var_node(rd_smspec, lookup_kw);
-    return smspec_node_get_unit(&smspec_node);
 }
 
 int rd_smspec_get_time_seconds(const rd_smspec_type *rd_smspec) {
@@ -1623,11 +1248,6 @@ rd_smspec_get_params_default(const rd_smspec_type *rd_smspec) {
 
 void rd_smspec_free(rd_smspec_type *rd_smspec) { delete rd_smspec; }
 
-void rd_smspec_free__(void *__rd_smspec) {
-    rd_smspec_type *rd_smspec = rd_smspec_safe_cast(__rd_smspec);
-    rd_smspec_free(rd_smspec);
-}
-
 int rd_smspec_get_date_day_index(const rd_smspec_type *smspec) {
     return smspec->day_index;
 }
@@ -1638,19 +1258,6 @@ int rd_smspec_get_date_month_index(const rd_smspec_type *smspec) {
 
 int rd_smspec_get_date_year_index(const rd_smspec_type *smspec) {
     return smspec->year_index;
-}
-
-/**
-   This function checks whether an input general key (i.e. FWPR or
-   GGPT:NORTH) represents an accumulated total. If the variable is not
-   internalized the function will fail hard.
-*/
-
-bool rd_smspec_general_is_total(const rd_smspec_type *smspec,
-                                const char *gen_key) {
-    const rd::smspec_node &smspec_node =
-        rd_smspec_get_general_var_node(smspec, gen_key);
-    return smspec_node_is_total(&smspec_node);
 }
 
 /**
@@ -1713,10 +1320,6 @@ rd_smspec_alloc_matching_general_var_list(const rd_smspec_type *smspec,
     return keys;
 }
 
-const char *rd_smspec_get_join_string(const rd_smspec_type *smspec) {
-    return smspec->key_join_string.c_str();
-}
-
 /**
     Returns a stringlist instance with all the (valid) well names. It
     is the responsability of the calling scope to free the stringlist
@@ -1762,39 +1365,9 @@ stringlist_type *rd_smspec_alloc_group_list(const rd_smspec_type *smspec,
     return rd_smspec_alloc_map_list(smspec->group_var_index, pattern);
 }
 
-/**
-    Returns a stringlist instance with all the well variables.  It is
-    the responsability of the calling scope to free the stringlist
-    with stringlist_free();
-*/
-
-stringlist_type *rd_smspec_alloc_well_var_list(const rd_smspec_type *smspec) {
-    stringlist_type *stringlist = stringlist_alloc_new();
-    for (const auto &pair : smspec->well_var_index)
-        stringlist_append_copy(stringlist, pair.first.c_str());
-
-    return stringlist;
-}
-
 const int *rd_smspec_get_grid_dims(const rd_smspec_type *smspec) {
     return smspec->grid_dims;
 }
-
-char *rd_smspec_alloc_well_key(const rd_smspec_type *smspec,
-                               const char *keyword, const char *wgname) {
-    return smspec_alloc_well_key(smspec->key_join_string.c_str(), keyword,
-                                 wgname);
-}
-
-/*void rd_smspec_sort( rd_smspec_type * smspec ) {
-  std::sort(smspec->smspec_nodes.begin(), smspec->smspec_nodes.end(), smspec_node_lt);
-
-  for (int i=0; i < static_cast<int>(smspec->smspec_nodes.size()); i++) {
-    rd::smspec_node& node = *smspec->smspec_nodes[i].get();
-    smspec_node_set_params_index( &node , i );
-  }
-}
-*/
 
 ert_rd_unit_enum rd_smspec_get_unit_system(const rd_smspec_type *smspec) {
     return smspec->unit_system;

--- a/lib/resdata/rd_type.cpp
+++ b/lib/resdata/rd_type.cpp
@@ -177,8 +177,3 @@ bool rd_type_is_bool(const rd_data_type rd_type) {
 bool rd_type_is_string(const rd_data_type rd_type) {
     return (rd_type.type == RD_STRING_TYPE);
 }
-
-// Temporary fixup for OPM.
-char *rd_type_get_name(const rd_data_type rd_type) {
-    return rd_type_alloc_name(rd_type);
-}

--- a/lib/resdata/well_rseg_loader.cpp
+++ b/lib/resdata/well_rseg_loader.cpp
@@ -40,11 +40,6 @@ well_rseg_loader_type *well_rseg_loader_alloc(rd_file_view_type *rst_view) {
     return loader;
 }
 
-int well_rseg_loader_element_count(
-    const well_rseg_loader_type *well_rseg_loader) {
-    return int_vector_size(well_rseg_loader->relative_index_map);
-}
-
 void well_rseg_loader_free(well_rseg_loader_type *loader) {
 
     if (rd_file_view_flags_set(loader->rst_view, RD_FILE_CLOSE_STREAM))


### PR DESCRIPTION
Removes unused c code now that only the python api and executables are considered public interface:

The current files that have been searched for unused c code
- [x] lib/util/buffer.cpp
- [x] lib/util/hash.cpp
- [x] lib/util/path_stack.cpp
- [x] lib/util/parser.cpp
- [x] lib/util/statistics.cpp
- [x] lib/util/cxx_string_util.cpp
- [x] lib/util/util.cpp
- [x] lib/util/util_opendir.cpp
- [x] lib/util/lookup_table.cpp
- [x] lib/util/util_unlink.cpp
- [x] lib/util/node_ctype.cpp
- [x] lib/util/string_util.cpp
- [x] lib/util/path.cpp
- [x] lib/util/util_lockf.cpp
- [x] lib/util/perm_vector.cpp
- [x] lib/util/util_symlink.cpp
- [x] lib/util/hash_sll.cpp
- [x] lib/util/util_abort.cpp
- [x] lib/util/util_zlib.cpp
- [x] lib/util/util_endian.cpp
- [x] lib/util/node_data.cpp
- [x] lib/util/test_work_area.cpp
- [x] lib/util/util_spawn.cpp
- [x] lib/util/mzran.cpp
- [x] lib/util/util_getuid.cpp
- [x] lib/util/test_util.cpp
- [x] lib/util/rd_version.cpp
- [x] lib/util/rng.cpp
- [x] lib/util/stringlist.cpp
- [x] lib/util/vector.cpp
- [x] lib/util/hash_node.cpp
- [x] lib/util/type_vector_functions.cpp
- [x] lib/resdata/rd_util.cpp
- [x] lib/resdata/rd_io_config.cpp
- [x] lib/resdata/rd_sum_tstep.cpp
- [x] lib/resdata/grid_dims.cpp
- [x] lib/resdata/rd_kw_functions.cpp
- [x] lib/resdata/rd_init_file.cpp
- [x] lib/resdata/well_state.cpp
- [x] lib/resdata/well_info.cpp
- [x] lib/resdata/smspec_node.cpp
- [x] lib/resdata/rd_rft_file.cpp
- [x] lib/resdata/rd_grav_common.cpp
- [x] lib/resdata/rd_rsthead.cpp
- [x] lib/resdata/rd_region.cpp
- [x] lib/resdata/rd_rft_cell.cpp
- [x] lib/resdata/rd_file_kw.cpp
- [x] lib/resdata/nnc_info.cpp
- [x] lib/resdata/rd_rst_file.cpp
- [x] lib/resdata/rd_box.cpp
- [x] lib/resdata/rd_grid_dims.cpp
- [x] lib/resdata/rd_sum_vector.cpp
- [x] lib/resdata/rd_grid_cache.cpp
- [x] lib/resdata/rd_kw.cpp
- [x] lib/resdata/well_conn_collection.cpp
- [x] lib/resdata/well_conn.cpp
- [x] lib/resdata/well_segment_collection.cpp
- [x] lib/resdata/rd_sum.cpp
- [x] lib/resdata/RDFilename.cpp
- [x] lib/resdata/rd_type_python.cpp
- [x] lib/resdata/rd_nnc_geometry.cpp
- [x] lib/resdata/rd_nnc_export.cpp
- [x] lib/resdata/rd_coarse_cell.cpp
- [x] lib/resdata/well_segment.cpp
- [x] lib/resdata/rd_sum_index.cpp
- [x] lib/resdata/nnc_vector.cpp
- [x] lib/resdata/well_branch_collection.cpp
- [x] lib/resdata/rd_sum_file_data.cpp
- [x] lib/resdata/rd_subsidence.cpp
- [x] lib/resdata/rd_unsmry_loader.cpp
- [x] lib/resdata/well_ts.cpp
- [x] lib/resdata/fault_block_layer.cpp
- [x] lib/resdata/rd_type.cpp
- [x] lib/resdata/FortIO.cpp
- [x] lib/resdata/well_rseg_loader.cpp
- [x] lib/resdata/rd_file_view.cpp
- [x] lib/resdata/rd_file.cpp
- [x] lib/resdata/rd_rft_node.cpp
- [x] lib/resdata/fault_block.cpp
- [x] lib/resdata/rd_smspec.cpp
- [x] lib/resdata/rd_sum_data.cpp
- [x] lib/resdata/layer.cpp
- [x] lib/resdata/rd_grav.cpp
- [x] lib/resdata/rd_nnc_data.cpp
- [x] lib/resdata/rd_grid.cpp
- [x] lib/resdata/rd_kw_grdecl.cpp
- [x] lib/geometry/geo_region.cpp
- [x] lib/geometry/geo_util.cpp
- [x] lib/geometry/geo_polygon.cpp
- [x] lib/geometry/geo_surface.cpp
- [x] lib/geometry/geo_polygon_collection.cpp
- [x] lib/geometry/geo_pointset.cpp

