### PR TITLE
Fix a buffer overflow in restart summary read

### DIFF
--- a/python/resdata/__init__.py
+++ b/python/resdata/__init__.py
@@ -29,6 +29,7 @@ If the fixed path, given by the default ../../lib64 or RESDATA_LIBRARY_PATH
 alternative fails, the loader will try the default load behaviour
 before giving up completely.
 """
+
 import ctypes as ct
 import os.path
 import sys

--- a/python/resdata/geometry/__init__.py
+++ b/python/resdata/geometry/__init__.py
@@ -2,6 +2,7 @@
 Simple package for working with 2D geometry.
 
 """
+
 import resdata
 from cwrap import Prototype
 

--- a/python/resdata/geometry/cpolyline.py
+++ b/python/resdata/geometry/cpolyline.py
@@ -1,6 +1,7 @@
 """
 Create a polygon
 """
+
 import ctypes
 import os.path
 

--- a/python/resdata/geometry/cpolyline_collection.py
+++ b/python/resdata/geometry/cpolyline_collection.py
@@ -1,6 +1,7 @@
 """
 Create a polygon
 """
+
 import ctypes
 
 from cwrap import BaseCClass

--- a/python/resdata/gravimetry/rd_subsidence.py
+++ b/python/resdata/gravimetry/rd_subsidence.py
@@ -6,6 +6,7 @@ results and calculate the change in seafloor subsidence between the
 different surveys. The implementation is a thin wrapper around the
 rd_subsidence.c implementation in the resdata library.
 """
+
 from cwrap import BaseCClass
 from resdata import ResdataPrototype
 from resdata.util.util import monkey_the_camel

--- a/python/resdata/grid/rd_grid.py
+++ b/python/resdata/grid/rd_grid.py
@@ -7,6 +7,7 @@ alone create a grid with rd_grid module. The functionality is
 implemented in the Grid class. The rd_grid module is a thin
 wrapper around the rd_grid.c implementation from the resdata library.
 """
+
 import ctypes
 
 import warnings

--- a/python/resdata/grid/rd_region.py
+++ b/python/resdata/grid/rd_region.py
@@ -10,6 +10,7 @@ combined e.g. with logical &.
 When the selection process is complete the region instance can be
 queried for the corresponding list of indices.
 """
+
 from functools import wraps
 import ctypes
 

--- a/python/resdata/rd_util.py
+++ b/python/resdata/rd_util.py
@@ -9,6 +9,7 @@ BaseCEnum class from cwrap.
 In addition to the enum definitions there are a few stateless
 functions from rd_util.c which are not bound to any class type.
 """
+
 from __future__ import absolute_import
 
 import ctypes

--- a/python/resdata/resfile/fortio.py
+++ b/python/resdata/resfile/fortio.py
@@ -21,6 +21,7 @@ python module is a minimal wrapping of this datastructure; mainly to
 support passing of FortIO handles to the underlying C functions. A
 more extensive wrapping of the fortio implementation would be easy.
 """
+
 import ctypes
 import os
 

--- a/python/resdata/resfile/rd_file.py
+++ b/python/resdata/resfile/rd_file.py
@@ -20,6 +20,7 @@ implementation from the resdata library.
 [1]: In particular for restart files, which do not have a special
      RestartFile class, there is some specialized functionality.
 """
+
 import ctypes
 import datetime
 import re

--- a/python/resdata/summary/__init__.py
+++ b/python/resdata/summary/__init__.py
@@ -4,7 +4,6 @@
      used as basis for queries on summary vectors.
 """
 
-
 import resdata.util.util
 import resdata.geometry
 

--- a/python/resdata/util/util/stringlist.py
+++ b/python/resdata/util/util/stringlist.py
@@ -15,6 +15,7 @@ be an iterable consisting of strings, and the strings property will
 return a normal python list of string objects, used in this way you
 hardly need to notice that the StringList class is at play.
 """
+
 from resdata import ResdataPrototype
 from cwrap import BaseCClass
 

--- a/python/tests/rd_tests/test_sum.py
+++ b/python/tests/rd_tests/test_sum.py
@@ -142,6 +142,8 @@ class SumTest(ResdataTest):
         )
         self.assertEqual(Summary.varType("RPR"), SummaryVarType.RD_SMSPEC_REGION_VAR)
         self.assertEqual(Summary.varType("WNEWTON"), SummaryVarType.RD_SMSPEC_MISC_VAR)
+        self.assertEqual(Summary.varType("YEAR"), SummaryVarType.RD_SMSPEC_MISC_VAR)
+        self.assertEqual(Summary.varType("MONTH"), SummaryVarType.RD_SMSPEC_MISC_VAR)
         self.assertEqual(
             Summary.varType("AARQ:4"), SummaryVarType.RD_SMSPEC_AQUIFER_VAR
         )

--- a/python/tests/rd_tests/test_sum_equinor.py
+++ b/python/tests/rd_tests/test_sum_equinor.py
@@ -488,8 +488,8 @@ class SumTest(ResdataTest):
         )
         self.assertIsNotNone(eclipse_summary)
 
-        hwell_padder = (
-            lambda key: key if key.split(":")[-1] != "HWELL_PR" else key + "OD"
+        hwell_padder = lambda key: (
+            key if key.split(":")[-1] != "HWELL_PR" else key + "OD"
         )
         self.assertEqual(
             intersect_summary.keys("WWCT*"),


### PR DESCRIPTION
The number of blocks of 8 character strings in the RESTART keyword can now be more than 9, and in any case the file could always have the length set to something larger, leading to stack corruption.
