### PR TITLE
Add ninja to the build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel", "scikit-build", "cmake", "conan<2"]
+requires = ["setuptools", "setuptools_scm", "wheel", "scikit-build", "cmake", "conan<2", "ninja"]


### PR DESCRIPTION
Currently ninja is listed as a dependency in requirements.txt and installed in CI, but is not listed in the build dependencies in pyproject.toml. 
