### PR TITLE
Remove broken function Layer.copy

### DIFF
--- a/python/resdata/grid/faults/layer.py
+++ b/python/resdata/grid/faults/layer.py
@@ -10,7 +10,6 @@ from resdata import ResdataPrototype
 class Layer(BaseCClass):
     TYPE_NAME = "rd_layer"
     _alloc = ResdataPrototype("void* layer_alloc(int,  int)", bind=False)
-    _copy = ResdataPrototype("void layer_memcpy(rd_layer, rd_layer)")
     _free = ResdataPrototype("void layer_free(rd_layer)")
     _get_nx = ResdataPrototype("int layer_get_nx(rd_layer)")
     _get_ny = ResdataPrototype("int layer_get_ny(rd_layer)")
@@ -53,12 +52,6 @@ class Layer(BaseCClass):
             super(Layer, self).__init__(c_ptr)
         else:
             raise ValueError("Invalid input - no Layer object created")
-
-    @classmethod
-    def copy(cls, src):
-        layer = Layer(src.getNX(), src.getNY())
-        layer._copy(src)
-        return layer
 
     def _assert_ij(self, i, j):
         if i < 0 or i >= self.getNX():

--- a/python/resdata/grid/faults/layer.py
+++ b/python/resdata/grid/faults/layer.py
@@ -57,7 +57,7 @@ class Layer(BaseCClass):
     @classmethod
     def copy(cls, src):
         layer = Layer(src.getNX(), src.getNY())
-        layer._copy(layer, src)
+        layer._copy(src)
         return layer
 
     def _assert_ij(self, i, j):

--- a/python/tests/rd_tests/test_layer.py
+++ b/python/tests/rd_tests/test_layer.py
@@ -18,12 +18,6 @@ class LayerTest(ResdataTest):
         layer = Layer(10, 10)
         self.assertTrue(isinstance(layer, Layer))
 
-    def test_layer_copy(self):
-        layer = Layer(10, 10)
-        layer_copy = Layer.copy(layer)
-        assert layer.get_nx() == layer_copy.get_nx()
-        assert layer.get_ny() == layer_copy.get_ny()
-
     def test_add_cell(self):
         layer = Layer(10, 10)
         with self.assertRaises(ValueError):

--- a/python/tests/rd_tests/test_layer.py
+++ b/python/tests/rd_tests/test_layer.py
@@ -18,6 +18,12 @@ class LayerTest(ResdataTest):
         layer = Layer(10, 10)
         self.assertTrue(isinstance(layer, Layer))
 
+    def test_layer_copy(self):
+        layer = Layer(10, 10)
+        layer_copy = Layer.copy(layer)
+        assert layer.get_nx() == layer_copy.get_nx()
+        assert layer.get_ny() == layer_copy.get_ny()
+
     def test_add_cell(self):
         layer = Layer(10, 10)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This function has thrown an IndexError on the parameters
since 45e1c3828208e29ea8ac4bc95eaeb34157cad2e4 (7 years ago as of this
commit). We have not gotten a bug report of this. We can therefore be pretty sure nobody is using it.
In order to work properly, the call to _copy should not have the first argument layer.
