### PR TITLE
Remove nonsensical time_interval.hpp

### DIFF
--- a/lib/include/ert/util/time_interval.hpp
+++ b/lib/include/ert/util/time_interval.hpp
@@ -1,6 +1,0 @@
-#ifndef TIME_INTERVAL_CXX
-#define TIME_INTERVAL_CXX
-
-#include <ert/util/time_interval.hpp>
-
-#endif


### PR DESCRIPTION
The header just includes itself which just blows up whenever used.
