### PR TITLE
Add test for non-existing resdata file

### DIFF
--- a/python/tests/rd_tests/test_rd_file.py
+++ b/python/tests/rd_tests/test_rd_file.py
@@ -1,4 +1,5 @@
 import shutil
+import pytest
 import datetime
 import os.path
 import gc
@@ -263,3 +264,8 @@ def test_report_list(tmpdir):
             assert rd_file.iget_restart_sim_days(1) == 0.0
             with openFortIO("TEST2.UNRST", FortIO.WRITE_MODE) as fortio:
                 rd_file.fwrite(fortio)
+
+
+def test_opening_non_existing_file_throws(tmpdir):
+    with pytest.raises(OSError):
+        ResdataFile("non_existing_file")


### PR DESCRIPTION
Resolves #786

Note that the `__repr__` in pytest part of this problem was solved in https://github.com/equinor/cwrap/commit/d9724697c7460aa8e7f7b4f2891458f98134ab3a . You can check this by setting a breakpoint in __init__ between `self._open` and `raise OSError` while running the added test and attempt to `print(self)`. This now raises an exception from cwrap.