### PR TITLE
Fix an issue where util_sscanf_int("") parsed as 0

### DIFF
--- a/lib/util/tests/ert_util_sscan_test.cpp
+++ b/lib/util/tests/ert_util_sscan_test.cpp
@@ -174,6 +174,12 @@ void test_sscanf_int() {
     test_assert_false(util_sscanf_int("7.5", &value));
     test_assert_int_equal(value, 1);
 
+    test_assert_false(util_sscanf_int("abc1", &value));
+    test_assert_int_equal(value, 1);
+
+    test_assert_false(util_sscanf_int("", &value));
+    test_assert_int_equal(value, 1);
+
     // max and min
     char buffer[30];
     snprintf(buffer, 30, "-%d", INT_MAX);

--- a/lib/util/util.cpp
+++ b/lib/util/util.cpp
@@ -1207,29 +1207,27 @@ bool util_sscanf_octal_int(const char *buffer, int *value) {
    true if the parsing succeeded, and false otherwise. If parsing
    succeeded, the integer value is returned by reference.
 */
-
 bool util_sscanf_int(const char *buffer, int *value) {
     if (!buffer)
         return false;
 
-    bool value_OK = false;
     char *error_ptr;
 
     int tmp_value = strtol(buffer, &error_ptr, 10);
 
-    /*
-    Skip trailing white-space
-  */
+    if (error_ptr == buffer)
+        return false;
 
+    // Skip trailing white-space
     while (error_ptr[0] != '\0' && isspace(error_ptr[0]))
         error_ptr++;
 
-    if (error_ptr[0] == '\0') {
-        value_OK = true;
-        if (value != NULL)
-            *value = tmp_value;
-    }
-    return value_OK;
+    if (error_ptr[0] != '\0')
+        return false;
+
+    if (value != NULL)
+        *value = tmp_value;
+    return true;
 }
 
 /*


### PR DESCRIPTION
**Issue**
Resolves #959 

the function is used in
* rd_get_start_date
* rd_get_num_parallel_cpu__
* string_util_sscanf_alloc_active_list
* rd_version_is_devel_version

Neither of which where interpreting "" as 0 is appropriate.

It is also used in `stringlist_iget_as_int`, but that function is getting removed as it is not used anywhere.