### PR TITLE
Make lookup_table_set_data static

### DIFF
--- a/lib/include/ert/util/lookup_table.hpp
+++ b/lib/include/ert/util/lookup_table.hpp
@@ -9,8 +9,6 @@ extern "C" {
 
 typedef struct lookup_table_struct lookup_table_type;
 
-void lookup_table_set_data(lookup_table_type *lt, double_vector_type *x,
-                           double_vector_type *y, bool data_owner);
 lookup_table_type *lookup_table_alloc(double_vector_type *x,
                                       double_vector_type *y, bool data_owner);
 lookup_table_type *lookup_table_alloc_empty();

--- a/lib/util/lookup_table.cpp
+++ b/lib/util/lookup_table.cpp
@@ -55,9 +55,8 @@ static void lookup_table_sort_data(lookup_table_type *lt) {
    IFF the @read_only flag is set to true; the x vector MUST be
    sorted.
 */
-
-void lookup_table_set_data(lookup_table_type *lt, double_vector_type *x,
-                           double_vector_type *y, bool data_owner) {
+static void lookup_table_set_data(lookup_table_type *lt, double_vector_type *x,
+                                  double_vector_type *y, bool data_owner) {
 
     if (lt->data_owner) {
         double_vector_free(lt->x_vector);


### PR DESCRIPTION
In relation to https://github.com/equinor/resdata/issues/954 we will remove c code that is not used to implement python functionality.

This PR is does only part of that and you can see the overview here: https://github.com/equinor/resdata/pull/949