### PR TITLE
Remove unused rng c code

### DIFF
--- a/lib/include/ert/util/rng.hpp
+++ b/lib/include/ert/util/rng.hpp
@@ -35,11 +35,7 @@ void rng_free(rng_type *rng);
 void rng_free(rng_type *rng);
 unsigned int rng_forward(rng_type *rng);
 double rng_get_double(rng_type *rng);
-void rng_rng_init(rng_type *rng, rng_type *seed_src);
 void rng_init(rng_type *rng, rng_init_mode init_mode);
-rng_alg_type rng_get_type(const rng_type *rng);
-void rng_fprintf_state(rng_type *rng, FILE *stream);
-void rng_fscanf_state(rng_type *rng, FILE *stream);
 int rng_state_size(const rng_type *rng);
 void rng_save_state(rng_type *rng, const char *filename);
 void rng_load_state(rng_type *rng, const char *filename);
@@ -51,12 +47,6 @@ unsigned int rng_forward(rng_type *rng);
 double rng_get_double(rng_type *rng);
 int rng_get_int(rng_type *rng, int max_value);
 unsigned int rng_get_max_int(const rng_type *rng);
-
-double rng_std_normal(rng_type *rng);
-void rng_shuffle_int(rng_type *rng, int *data, size_t num_elements);
-void rng_shuffle(rng_type *rng, char *data, size_t element_size,
-                 size_t num_elements);
-void rng_free__(void *arg);
 
 UTIL_SAFE_CAST_HEADER(rng);
 


### PR DESCRIPTION
In relation to https://github.com/equinor/resdata/issues/954 we will remove c code that is not used to implement python functionality.

This PR is does only part of that and you can see the overview here: https://github.com/equinor/resdata/pull/949