### PR TITLE
Fix pytest.mark typo and associated tmpdir-bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [build-system]
 requires = ["setuptools", "setuptools_scm", "wheel", "scikit-build", "cmake", "conan<2", "ninja"]
+
+[too.pytest.ini_options]
+addopts = "--strict-markers"

--- a/python/tests/rd_tests/test_rd_sum.py
+++ b/python/tests/rd_tests/test_rd_sum.py
@@ -159,12 +159,12 @@ class SummaryTest(ResdataTest):
 
 @pytest.fixture
 def use_tmpdir(tmpdir):
-    with tmpdir.as_wcd():
+    with tmpdir.as_cwd():
         yield
 
 
 @given(summaries())
-@pytest.mark.use_fixtures("use_tmpdir")
+@pytest.mark.usefixtures("use_tmpdir")
 def test_to_from_pandas(summary):
     smspec, unsmry = summary
     assume(len(smspec.keywords) == len(set(smspec.keywords)))
@@ -193,7 +193,7 @@ def test_to_from_pandas(summary):
 
 
 @given(summaries())
-@pytest.mark.use_fixtures("use_tmpdir")
+@pytest.mark.usefixtures("use_tmpdir")
 def test_that_non_matching_dataframe_gives_empty_columns(summary):
     smspec, unsmry = summary
     assume("BOGUS" not in (smspec.keywords))


### PR DESCRIPTION
* Fix bug that only occurs when the fixture is actually activated.
* Enforce strict markers
