### PR TITLE
Use GridGenerator in tests

### DIFF
--- a/python/tests/rd_tests/test_fault_blocks.py
+++ b/python/tests/rd_tests/test_fault_blocks.py
@@ -4,7 +4,7 @@ import cwrap
 
 from resdata import ResDataType
 from resdata.resfile import ResdataKW
-from resdata.grid import Grid, ResdataRegion
+from resdata.grid import Grid, ResdataRegion, GridGenerator
 from resdata.grid.faults import FaultBlock, FaultBlockLayer, FaultCollection
 from resdata.geometry import Polyline, CPolylineCollection
 from resdata.util.test import TestAreaContext
@@ -13,7 +13,7 @@ from tests import ResdataTest
 
 class FaultBlockTest(ResdataTest):
     def setUp(self):
-        self.grid = Grid.createRectangular((10, 10, 10), (1, 1, 1))
+        self.grid = GridGenerator.create_rectangular((10, 10, 10), (1, 1, 1))
         self.kw = ResdataKW("FAULTBLK", self.grid.getGlobalSize(), ResDataType.RD_INT)
         self.kw.assign(1)
 
@@ -26,7 +26,7 @@ class FaultBlockTest(ResdataTest):
             self.kw[k * self.grid.getNX() * self.grid.getNY() + 7] = 177
 
     def test_fault_block(self):
-        grid = Grid.createRectangular((5, 5, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((5, 5, 1), (1, 1, 1))
         kw = ResdataKW("FAULTBLK", grid.getGlobalSize(), ResDataType.RD_INT)
         kw.assign(0)
         for j in range(1, 4):
@@ -55,7 +55,7 @@ class FaultBlockTest(ResdataTest):
             with cwrap.open("kw.grdecl") as f:
                 kw = ResdataKW.read_grdecl(f, "FAULTBLK", rd_type=ResDataType.RD_INT)
 
-        grid = Grid.createRectangular((5, 5, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((5, 5, 1), (1, 1, 1))
         layer = FaultBlockLayer(grid, 0)
         layer.loadKeyword(kw)
 
@@ -85,7 +85,7 @@ class FaultBlockTest(ResdataTest):
             with cwrap.open("kw.grdecl") as f:
                 kw = ResdataKW.read_grdecl(f, "FAULTBLK", rd_type=ResDataType.RD_INT)
 
-        grid = Grid.createRectangular((5, 5, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((5, 5, 1), (1, 1, 1))
         layer = FaultBlockLayer(grid, 0)
 
         layer.loadKeyword(kw)
@@ -125,7 +125,7 @@ class FaultBlockTest(ResdataTest):
         nx = 8
         ny = 8
         nz = 1
-        grid = Grid.createRectangular((nx, ny, nz), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((nx, ny, nz), (1, 1, 1))
         layer = FaultBlockLayer(grid, 0)
         with TestAreaContext("python/FaultBlocks/neighbours"):
             with open("faultblock.grdecl", "w") as fileH:
@@ -189,7 +189,7 @@ class FaultBlockTest(ResdataTest):
         nx = 8
         ny = 8
         nz = 1
-        grid = Grid.createRectangular((nx, ny, nz), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((nx, ny, nz), (1, 1, 1))
         layer = FaultBlockLayer(grid, 0)
         with TestAreaContext("python/FaultBlocks/neighbours"):
             with open("faultblock.grdecl", "w") as fileH:
@@ -225,7 +225,7 @@ class FaultBlockTest(ResdataTest):
         self.assertTrue(b2 in nb)
 
     def test_fault_block_edge(self):
-        grid = Grid.createRectangular((5, 5, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((5, 5, 1), (1, 1, 1))
         kw = ResdataKW("FAULTBLK", grid.getGlobalSize(), ResDataType.RD_INT)
         kw.assign(0)
         for j in range(1, 4):
@@ -333,7 +333,7 @@ class FaultBlockTest(ResdataTest):
         self.assertEqual([1, 2, 3], list(fault_block.getRegionList()))
 
     def test_add_polyline_barrier1(self):
-        grid = Grid.createRectangular((4, 1, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((4, 1, 1), (1, 1, 1))
         layer = FaultBlockLayer(self.grid, 0)
         polyline = Polyline(init_points=[(1.99, 0.001), (2.01, 0.99)])
 
@@ -349,7 +349,7 @@ class FaultBlockTest(ResdataTest):
             self.assertFalse(geo_layer.cellContact(p1, p2))
 
     def test_add_polyline_barrier2(self):
-        grid = Grid.createRectangular((10, 10, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((10, 10, 1), (1, 1, 1))
         layer = FaultBlockLayer(self.grid, 0)
         polyline = Polyline(init_points=[(0.1, 0.9), (8.9, 0.9), (8.9, 8.9)])
 
@@ -389,7 +389,7 @@ class FaultBlockTest(ResdataTest):
         nx = 8
         ny = 8
         nz = 1
-        grid = Grid.createRectangular((nx, ny, nz), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((nx, ny, nz), (1, 1, 1))
         layer = FaultBlockLayer(grid, 0)
         with TestAreaContext("python/FaultBlocks/internal_blocks"):
             with open("faultblock.grdecl", "w") as fileH:

--- a/python/tests/rd_tests/test_faults.py
+++ b/python/tests/rd_tests/test_faults.py
@@ -5,7 +5,7 @@ from resdata import util
 
 from resdata import ResDataType
 from resdata.resfile import ResdataKW
-from resdata.grid import Grid
+from resdata.grid import Grid, GridGenerator
 from resdata.grid.faults import (
     FaultCollection,
     Fault,
@@ -21,7 +21,7 @@ from tests import ResdataTest
 class FaultTest(ResdataTest):
     @classmethod
     def setUpClass(cls):
-        cls.grid = Grid.createRectangular((151, 100, 50), (1, 1, 1))
+        cls.grid = GridGenerator.create_rectangular((151, 100, 50), (1, 1, 1))
 
     def setUp(self):
         self.faults1 = self.createTestPath("local/ECLIPSE/FAULTS/fault1.grdecl")
@@ -31,7 +31,7 @@ class FaultTest(ResdataTest):
         nx = 10
         ny = 10
         nz = 10
-        grid = Grid.createRectangular((nx, ny, nz), (0.1, 0.1, 0.1))
+        grid = GridGenerator.create_rectangular((nx, ny, nz), (0.1, 0.1, 0.1))
         f = Fault(grid, "F")
         f.addRecord(0, 1, 0, 0, 0, 0, "Y-")
         f.addRecord(2, 2, 0, 1, 0, 0, "X-")
@@ -112,7 +112,7 @@ class FaultTest(ResdataTest):
         nx = 10
         ny = 10
         nz = 2
-        grid = Grid.createRectangular((nx, ny, nz), (0.1, 0.1, 0.1))
+        grid = GridGenerator.create_rectangular((nx, ny, nz), (0.1, 0.1, 0.1))
         fl = FaultLine(grid, 0)
         C1 = (nx + 1) * 5 + 3
         C2 = C1 + 2
@@ -191,7 +191,7 @@ class FaultTest(ResdataTest):
             faults.load(self.grid, "No/this/does/not/exist")
 
     def test_connect_faults(self):
-        grid = Grid.createRectangular((100, 100, 10), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((100, 100, 10), (1, 1, 1))
 
         #    Fault1                    Fault4
         #      |                         |
@@ -342,7 +342,7 @@ class FaultTest(ResdataTest):
         self.assertEqual(join, [p1, p2])
 
     def test_join_faults(self):
-        grid = Grid.createRectangular((100, 100, 10), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((100, 100, 10), (1, 1, 1))
 
         #    Fault1                    Fault4
         #      |                         |
@@ -373,7 +373,7 @@ class FaultTest(ResdataTest):
         self.assertEqual(extra, [(2, 10), (2, 6), (5, 6)])
 
     def test_contact(self):
-        grid = Grid.createRectangular((100, 100, 10), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((100, 100, 10), (1, 1, 1))
 
         #    Fault1                    Fault4
         #      |                         |
@@ -471,7 +471,7 @@ class FaultTest(ResdataTest):
         nx = 120
         ny = 60
         nz = 43
-        grid = Grid.createRectangular((nx, ny, nz), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((nx, ny, nz), (1, 1, 1))
         with TestAreaContext("python/faults/line_order"):
             with open("faults.grdecl", "w") as f:
                 f.write(
@@ -509,7 +509,7 @@ class FaultTest(ResdataTest):
         nx = 10
         ny = 8
         nz = 7
-        grid = Grid.createRectangular((nx, ny, nz), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((nx, ny, nz), (1, 1, 1))
         faults_file = self.createTestPath("local/ECLIPSE/FAULTS/faults_nb.grdecl")
         faults = FaultCollection(grid, faults_file)
 
@@ -570,7 +570,7 @@ class FaultTest(ResdataTest):
         self.assertListEqual(nb_cells1, true_nb_cells1)
 
     def test_polyline_intersection(self):
-        grid = Grid.createRectangular((100, 100, 10), (0.25, 0.25, 1))
+        grid = GridGenerator.create_rectangular((100, 100, 10), (0.25, 0.25, 1))
 
         #    Fault1                    Fault4
         #      |                         |
@@ -609,7 +609,7 @@ class FaultTest(ResdataTest):
         nx = 10
         ny = 10
         nz = 1
-        grid = Grid.createRectangular((nx, ny, nz), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((nx, ny, nz), (1, 1, 1))
         with TestAreaContext("python/faults/line_order"):
             with open("faults.grdecl", "w") as f:
                 f.write(
@@ -628,7 +628,7 @@ class FaultTest(ResdataTest):
             self.assertEqual(1, f2.numLines(0))
 
     def test_extend_to_polyline(self):
-        grid = Grid.createRectangular((3, 3, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((3, 3, 1), (1, 1, 1))
 
         #  o   o   o   o
         #
@@ -655,7 +655,7 @@ class FaultTest(ResdataTest):
         self.assertIsNone(end_join)
 
     def test_extend_polyline_on(self):
-        grid = Grid.createRectangular((3, 3, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((3, 3, 1), (1, 1, 1))
 
         #  o   o   o   o
         #
@@ -686,7 +686,7 @@ class FaultTest(ResdataTest):
         self.assertIsNone(points)
 
     def test_stepped(self):
-        grid = Grid.createRectangular((6, 1, 4), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((6, 1, 4), (1, 1, 1))
         f = Fault(grid, "F")
         f.addRecord(4, 4, 0, 0, 0, 1, "X")
         f.addRecord(2, 2, 0, 0, 1, 1, "Z")
@@ -725,7 +725,7 @@ class FaultTest(ResdataTest):
         self.assertFalse(layer3.cellContact((1, 0), (2, 0)))
 
     def test_connectWithPolyline(self):
-        grid = Grid.createRectangular((4, 4, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((4, 4, 1), (1, 1, 1))
 
         #  o   o   o   o   o
         #

--- a/python/tests/rd_tests/test_geertsma.py
+++ b/python/tests/rd_tests/test_geertsma.py
@@ -2,7 +2,7 @@ import datetime
 import pytest
 from resdata import ResDataType
 from resdata.resfile import ResdataKW, openFortIO, FortIO, ResdataFile
-from resdata.grid import Grid
+from resdata.grid import GridGenerator
 from resdata.gravimetry import ResdataSubsidence
 
 from resdata.util.test import TestAreaContext
@@ -27,7 +27,7 @@ def create_init(grid, case):
 class GeertsmaTest(ResdataTest):
     @staticmethod
     def test_geertsma_kernel():
-        grid = Grid.createRectangular(dims=(1, 1, 1), dV=(50, 50, 50))
+        grid = GridGenerator.create_rectangular(dims=(1, 1, 1), dV=(50, 50, 50))
         with TestAreaContext("Subsidence"):
             p1 = [1]
             create_restart(grid, "TEST", p1)
@@ -67,7 +67,7 @@ class GeertsmaTest(ResdataTest):
 
     @staticmethod
     def test_geertsma_kernel_2_source_points_2_vintages():
-        grid = Grid.createRectangular(dims=(2, 1, 1), dV=(100, 100, 100))
+        grid = GridGenerator.create_rectangular(dims=(2, 1, 1), dV=(100, 100, 100))
 
         with TestAreaContext("Subsidence"):
             p1 = [1, 10]
@@ -109,7 +109,7 @@ class GeertsmaTest(ResdataTest):
 
     @staticmethod
     def test_geertsma_kernel_seabed():
-        grid = Grid.createRectangular(dims=(1, 1, 1), dV=(50, 50, 50))
+        grid = GridGenerator.create_rectangular(dims=(1, 1, 1), dV=(50, 50, 50))
         with TestAreaContext("Subsidence"):
             p1 = [1]
             create_restart(grid, "TEST", p1)
@@ -137,7 +137,7 @@ class GeertsmaTest(ResdataTest):
 
     @staticmethod
     def test_geertsma_kernel_seabed():
-        grid = Grid.createRectangular(dims=(1, 1, 1), dV=(50, 50, 50))
+        grid = GridGenerator.create_rectangular(dims=(1, 1, 1), dV=(50, 50, 50))
         with TestAreaContext("Subsidence"):
             p1 = [1]
             create_restart(grid, "TEST", p1)
@@ -164,7 +164,7 @@ class GeertsmaTest(ResdataTest):
             np.testing.assert_almost_equal(dz, 5.819790154474284e-08)
 
     def test_geertsma_rporv_kernel_2_source_points_2_vintages(self):
-        grid = Grid.createRectangular(dims=(2, 1, 1), dV=(100, 100, 100))
+        grid = GridGenerator.create_rectangular(dims=(2, 1, 1), dV=(100, 100, 100))
 
         with TestAreaContext("Subsidence"):
             p1 = [1, 10]

--- a/python/tests/rd_tests/test_grav.py
+++ b/python/tests/rd_tests/test_grav.py
@@ -1,7 +1,7 @@
 import datetime
 from resdata import ResDataType
 from resdata.resfile import ResdataKW, ResdataFile, openFortIO, FortIO
-from resdata.grid import Grid
+from resdata.grid import GridGenerator
 from resdata.gravimetry import ResdataGrav
 from resdata.util.test import TestAreaContext
 from tests import ResdataTest
@@ -10,7 +10,7 @@ from resdata.rd_util import Phase
 
 class ResdataGravTest(ResdataTest):
     def setUp(self):
-        self.grid = Grid.createRectangular((10, 10, 10), (1, 1, 1))
+        self.grid = GridGenerator.create_rectangular((10, 10, 10), (1, 1, 1))
 
     def test_create(self):
         kws = [

--- a/python/tests/rd_tests/test_grid_equinor.py
+++ b/python/tests/rd_tests/test_grid_equinor.py
@@ -119,7 +119,7 @@ class GridTest(ResdataTest):
             a1 = 1.0
             a2 = 2.0
             a3 = 3.0
-            grid = Grid.createRectangular((9, 9, 9), (a1, a2, a3))
+            grid = GridGenerator.create_rectangular((9, 9, 9), (a1, a2, a3))
             grid.save_EGRID("rect.EGRID")
             grid2 = Grid("rect.EGRID")
             self.assertTrue(grid)
@@ -163,7 +163,9 @@ class GridTest(ResdataTest):
 
             actnum = IntVector(default_value=1, initial_size=1000)
             actnum[0] = 0
-            g1 = Grid.createRectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
+            g1 = GridGenerator.create_rectangular(
+                (10, 10, 10), (1, 1, 1), actnum=actnum
+            )
             self.assertEqual(g1.getNumActive(), actnum.elementSum())
             g1.save_EGRID("G.EGRID")
 
@@ -220,7 +222,7 @@ class GridTest(ResdataTest):
             g = Grid("/does/not/exist.EGRID")
 
     def test_boundingBox(self):
-        grid = Grid.createRectangular((10, 10, 10), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((10, 10, 10), (1, 1, 1))
         with self.assertRaises(ValueError):
             bbox = grid.getBoundingBox2D(layer=-1)
 

--- a/python/tests/rd_tests/test_grid_pandas.py
+++ b/python/tests/rd_tests/test_grid_pandas.py
@@ -6,14 +6,16 @@ from resdata import ResdataTypeEnum
 
 from resdata.resfile import ResdataKW
 
-from resdata.grid import Grid
+from resdata.grid import Grid, GridGenerator
 
 from tests import ResdataTest
 
 
 class GridPandasTest(ResdataTest):
     def test_dataframe_actnum(self):
-        grid = Grid.create_rectangular((2, 3, 1), (1, 1, 1), actnum=[1, 1, 0, 0, 1, 1])
+        grid = GridGenerator.create_rectangular(
+            (2, 3, 1), (1, 1, 1), actnum=[1, 1, 0, 0, 1, 1]
+        )
         df = grid.export_index(True)
         index_matrix = np.array(
             [[0, 0, 0, 0], [1, 0, 0, 1], [0, 2, 0, 2], [1, 2, 0, 3]]
@@ -70,7 +72,9 @@ class GridPandasTest(ResdataTest):
         assert np.array_equal(data, np.array([10.5, 9.25, 2222.0, 2222.0, 2.0, 1.625]))
 
     def test_dataframe_grid_data(self):
-        grid = Grid.create_rectangular((2, 3, 1), (1, 1, 1), actnum=[1, 1, 0, 0, 1, 1])
+        grid = GridGenerator.create_rectangular(
+            (2, 3, 1), (1, 1, 1), actnum=[1, 1, 0, 0, 1, 1]
+        )
         index_frame = grid.export_index()
         volume_data = grid.export_volume(index_frame)
         assert len(volume_data) == 6

--- a/python/tests/rd_tests/test_kw_function.py
+++ b/python/tests/rd_tests/test_kw_function.py
@@ -3,7 +3,7 @@ import os
 import random
 from resdata import ResDataType
 from resdata.resfile import ResdataKW, Resdata3DKW
-from resdata.grid import Grid
+from resdata.grid import GridGenerator
 from resdata.util.util import IntVector
 from tests import ResdataTest
 
@@ -16,7 +16,7 @@ class KWFunctionTest(ResdataTest):
         actnum = IntVector(initial_size=nx * ny * nz, default_value=1)
         actnum[nx * ny - 1] = 0
 
-        grid = Grid.createRectangular((nx, ny, nz), (1, 1, 1), actnum=actnum)
+        grid = GridGenerator.create_rectangular((nx, ny, nz), (1, 1, 1), actnum=actnum)
         self.assertEqual(grid.getNumActive(), nx * ny * nz - 1)
 
         kw = Resdata3DKW.create("REGIONS", grid, ResDataType.RD_INT, global_active=True)

--- a/python/tests/rd_tests/test_layer.py
+++ b/python/tests/rd_tests/test_layer.py
@@ -3,7 +3,7 @@ from unittest import skipIf
 import time
 
 from resdata.util.util import IntVector
-from resdata.grid import Grid
+from resdata.grid import GridGenerator
 from resdata.geometry import CPolyline
 from resdata.grid.faults import Layer, FaultCollection
 from resdata.util.test import TestAreaContext
@@ -36,7 +36,7 @@ class LayerTest(ResdataTest):
         nx = 20
         ny = 10
         layer = Layer(nx, ny)
-        grid = Grid.createRectangular((nx, ny, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((nx, ny, 1), (1, 1, 1))
 
         with self.assertRaises(IndexError):
             layer.cellContact((-1, 0), (1, 1))
@@ -90,7 +90,7 @@ class LayerTest(ResdataTest):
         nx = 120
         ny = 60
         nz = 43
-        grid = Grid.createRectangular((nx, ny, nz), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((nx, ny, nz), (1, 1, 1))
         with TestAreaContext("python/faults/line_order"):
             with open("faults.grdecl", "w") as f:
                 f.write(
@@ -149,7 +149,7 @@ class LayerTest(ResdataTest):
         nx = 10
         ny = 10
         layer = Layer(nx, ny)
-        grid = Grid.createRectangular((nx, ny, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((nx, ny, 1), (1, 1, 1))
 
         # Too short
         with self.assertRaises(ValueError):
@@ -228,7 +228,7 @@ class LayerTest(ResdataTest):
     def test_add_polyline_barrier(self):
         d = 10
         layer = Layer(d, d)
-        grid = Grid.createRectangular((d, d, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((d, d, 1), (1, 1, 1))
         pl = CPolyline(init_points=[(0, 0), (d / 2, d / 2), (d, d)])
         layer.addPolylineBarrier(pl, grid, 0)
         for i in range(d):
@@ -244,17 +244,17 @@ class LayerTest(ResdataTest):
 
         self.assertTrue(layer.activeCell(1, 2))
 
-        grid = Grid.createRectangular((d, d + 1, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((d, d + 1, 1), (1, 1, 1))
         with self.assertRaises(ValueError):
             layer.updateActive(grid, 0)
 
-        grid = Grid.createRectangular((d, d, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((d, d, 1), (1, 1, 1))
         with self.assertRaises(ValueError):
             layer.updateActive(grid, 10)
 
         actnum = IntVector(initial_size=d * d * 1, default_value=1)
         actnum[0] = 0
-        grid = Grid.createRectangular((d, d, 1), (1, 1, 1), actnum=actnum)
+        grid = GridGenerator.create_rectangular((d, d, 1), (1, 1, 1), actnum=actnum)
         layer.updateActive(grid, 0)
         self.assertTrue(layer.activeCell(1, 2))
         self.assertFalse(layer.activeCell(0, 0))

--- a/python/tests/rd_tests/test_rd_3dkw.py
+++ b/python/tests/rd_tests/test_rd_3dkw.py
@@ -5,7 +5,7 @@ import random
 from resdata.util.util import IntVector
 from resdata import ResDataType, FileMode
 from resdata.resfile import Resdata3DKW, ResdataKW, ResdataFile, FortIO
-from resdata.grid import Grid
+from resdata.grid import GridGenerator
 from resdata.util.test import TestAreaContext
 from tests import ResdataTest
 
@@ -16,7 +16,7 @@ class Resdata3DKWTest(ResdataTest):
         for i in range(100):
             actnum[i] = 0
 
-        grid = Grid.createRectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
+        grid = GridGenerator.create_rectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
         kw = Resdata3DKW("KW", grid, ResDataType.RD_FLOAT)
         self.assertEqual(len(kw), grid.getNumActive())
 
@@ -27,7 +27,7 @@ class Resdata3DKWTest(ResdataTest):
         for i in range(100):
             actnum[i] = 0
 
-        grid = Grid.createRectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
+        grid = GridGenerator.create_rectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
         kw = Resdata3DKW("KW", grid, ResDataType.RD_FLOAT, global_active=True)
         self.assertEqual(len(kw), grid.getGlobalSize())
 
@@ -41,7 +41,7 @@ class Resdata3DKWTest(ResdataTest):
         nx = 10
         ny = 11
         nz = 12
-        grid = Grid.createRectangular((nx, ny, nz), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((nx, ny, nz), (1, 1, 1))
         kw = Resdata3DKW("REGIONS", grid, ResDataType.RD_INT, global_active=True)
         kw.assign(3)
         self.assertEqual(3 * nx * ny * nz, sum(kw))
@@ -59,7 +59,7 @@ class Resdata3DKWTest(ResdataTest):
         for i in range(100):
             actnum[i] = 0
 
-        grid = Grid.createRectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
+        grid = GridGenerator.create_rectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
         kw = Resdata3DKW("KW", grid, ResDataType.RD_FLOAT, default_value=77)
 
         with self.assertRaises(IndexError):
@@ -84,7 +84,7 @@ class Resdata3DKWTest(ResdataTest):
         for i in range(100):
             actnum[i] = 0
 
-        grid = Grid.createRectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
+        grid = GridGenerator.create_rectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
         kw = Resdata3DKW("KW", grid, ResDataType.RD_FLOAT, default_value=77)
 
         with self.assertRaises(IndexError):
@@ -114,7 +114,7 @@ class Resdata3DKWTest(ResdataTest):
         for i in range(100):
             actnum[i] = 0
 
-        grid = Grid.createRectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
+        grid = GridGenerator.create_rectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
         kw_wrong_size = ResdataKW("KW", 27, ResDataType.RD_FLOAT)
         kw_global_size = ResdataKW("KW", grid.getGlobalSize(), ResDataType.RD_FLOAT)
         kw_active_size = ResdataKW("KW", grid.getNumActive(), ResDataType.RD_FLOAT)
@@ -133,7 +133,7 @@ class Resdata3DKWTest(ResdataTest):
             kw_active_size[0, 0, 0] = 88
 
     def test_default(self):
-        grid = Grid.createRectangular((10, 10, 10), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((10, 10, 10), (1, 1, 1))
         kw = Resdata3DKW("KW", grid, ResDataType.RD_FLOAT)
         kw.setDefault(55)
         self.assertTrue(55, kw.getDefault())
@@ -143,7 +143,7 @@ class Resdata3DKWTest(ResdataTest):
         for i in range(500):
             actnum[2 * i + 1] = 0
 
-        grid = Grid.createRectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
+        grid = GridGenerator.create_rectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
         kw = Resdata3DKW("KW", grid, ResDataType.RD_INT, global_active=True)
         for i in range(len(kw)):
             kw[i] = i
@@ -160,7 +160,7 @@ class Resdata3DKWTest(ResdataTest):
         for i in range(500):
             actnum[2 * i + 1] = 0
 
-        grid = Grid.createRectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
+        grid = GridGenerator.create_rectangular((10, 10, 10), (1, 1, 1), actnum=actnum)
         kw = Resdata3DKW("KW", grid, ResDataType.RD_INT, global_active=False)
         for i in range(len(kw)):
             kw[i] = i

--- a/python/tests/rd_tests/test_region.py
+++ b/python/tests/rd_tests/test_region.py
@@ -2,7 +2,7 @@ from resdata import ResDataType
 import numpy as np
 import pytest
 from resdata.resfile import ResdataKW
-from resdata.grid import Grid, ResdataRegion
+from resdata.grid import Grid, ResdataRegion, GridGenerator
 from resdata.util.util import IntVector
 from tests import ResdataTest
 from resdata.grid.faults import Layer
@@ -10,7 +10,7 @@ from resdata.grid.faults import Layer
 
 class RegionTest(ResdataTest):
     def test_equal(self):
-        grid = Grid.createRectangular((10, 10, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((10, 10, 1), (1, 1, 1))
         kw_int = ResdataKW("INT", grid.getGlobalSize(), ResDataType.RD_INT)
         kw_float = ResdataKW("FLOAT", grid.getGlobalSize(), ResDataType.RD_FLOAT)
 
@@ -25,7 +25,7 @@ class RegionTest(ResdataTest):
             region.select_equal(kw_float, 1)
 
     def test_sum(self):
-        grid = Grid.createRectangular((10, 10, 1), (1, 1, 1))
+        grid = GridGenerator.create_rectangular((10, 10, 1), (1, 1, 1))
         kw_mask = ResdataKW("INT", grid.getGlobalSize(), ResDataType.RD_INT)
         int_value = ResdataKW("INT", grid.getGlobalSize(), ResDataType.RD_INT)
         float_value = ResdataKW("FLOAT", grid.getGlobalSize(), ResDataType.RD_FLOAT)


### PR DESCRIPTION
Resolving deprecation warning from Grid.createRectangular
