### PR TITLE
Fix missing import for equinor-testdata

### DIFF
--- a/python/tests/rd_tests/test_grid_equinor.py
+++ b/python/tests/rd_tests/test_grid_equinor.py
@@ -12,7 +12,7 @@ from cwrap import open as copen
 import time
 from resdata import ResDataType, UnitSystem
 from resdata.resfile import ResdataKW, ResdataFile, openResdataFile
-from resdata.grid import Grid
+from resdata.grid import Grid, GridGenerator
 from resdata.util.util import DoubleVector, IntVector
 from resdata.util.test import TestAreaContext
 from tests import ResdataTest, equinor_test


### PR DESCRIPTION
**Issue**
Resolves failure when running with Equinor testdata present. Tested locally confirming it should work with Equinor testdata.

**Approach**
Do the import.