### PR TITLE
Restrict cmake to < 4

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,13 +1,11 @@
 # clang-format
 ---
-Language: Cpp
 BasedOnStyle: LLVM
 AccessModifierOffset: -4
 IndentWidth: 4
 
 # Our includes are not order-agnostic
-SortIncludes: false
+SortIncludes: Never
 
 # Some of our comments include insightful insight
 ReflowComments: false
-...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,13 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel", "scikit-build", "cmake", "conan<2", "ninja"]
+requires = [
+  "setuptools",
+  "setuptools_scm",
+  "wheel",
+  "scikit-build",
+  "cmake<4",
+  "conan<2",
+  "ninja",
+]
 
-[too.pytest.ini_options]
+[tool.pytest.ini_options]
 addopts = "--strict-markers"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cmake<4
 cwrap
 ninja
 numpy


### PR DESCRIPTION
restricting cmake to <4 due to errors caused by the upgrade

some packages built by conan give errors due to them not setting CMake minimum version to >= 3.5. 
> Compatibility with CMake < 3.5 has been removed from CMake.