### PR TITLE
Resolve Python 3.12 SyntaxWarning

### DIFF
--- a/python/resdata/resfile/rd_file.py
+++ b/python/resdata/resfile/rd_file.py
@@ -126,7 +126,7 @@ class ResdataFile(BaseCClass):
             # a non-unified restart file; or because this is not a
             # restart file at all.
             fname = self.getFilename()
-            matchObj = re.search("\.[XF](\d{4})$", fname)
+            matchObj = re.search(r"\.[XF](\d{4})$", fname)
             if matchObj:
                 report_steps.append(int(matchObj.group(1)))
             else:


### PR DESCRIPTION
**Issue**
Resolves Python 3.12 SyntaxWarning when building bytecode files
