### PR TITLE
Modify conan settings for macos-latest in github workflows

### DIFF
--- a/.github/actions/setup_conan_mac/action.yml
+++ b/.github/actions/setup_conan_mac/action.yml
@@ -1,0 +1,23 @@
+name: setup_conan_for_mac
+description: Add newest mac compilers to conan settings
+
+inputs:
+  os:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Modify conan settings
+      if: inputs.os == 'macos-latest'
+      run: |
+        python3 -m pip install "conan<2"
+        conan profile new default --detect --force
+        conan config init --force
+        if ! grep -q '"17.0"' ~/.conan/settings.yml; then
+          sed -i '' '/"16.0"\]/s/\]/\, "17", "17.0"\]/' ~/.conan/settings.yml
+          echo "Added Apple Clang 17.0 support to Conan settings"
+        else
+          echo "Apple Clang 17.0 already in Conan settings"
+        fi
+      shell: bash

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,6 +39,10 @@ jobs:
       run: |
         python3 -m pip install "conan<2"
 
+    - uses: ./.github/actions/setup_conan_mac
+      with:
+        os: ${{ matrix.os }}
+
 
     - name: Build
       run: |
@@ -90,6 +94,10 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
+
+    - uses: ./.github/actions/setup_conan_mac
+      with:
+        os: ${{ matrix.os }}
 
     - name: Build macOS Wheel
       if: runner.os == 'macOS'


### PR DESCRIPTION
**Issue**
Resolves #1055 

Not the most robust and portable solution, but other than pinning the mac version I am unsure what else to do since we are using conan 1.