### PR TITLE
Add missing linked stdc++fs to tests

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -382,7 +382,7 @@ foreach(
   well_lgr_load)
 
   add_executable(${name} resdata/tests/${name}.cpp util/test_util.cpp)
-  target_link_libraries(${name} resdata)
+  target_link_libraries(${name} resdata stdc++fs)
   target_include_directories(
     ${name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/private-include)
 endforeach()


### PR DESCRIPTION
It is used by rd_grid_dx_dy_dz. This was not caught before because explicitly linking stdc++fs is not required on all distros.

