### PR TITLE
Fix breaking change in return types

### DIFF
--- a/python/resdata/rft/rd_rft.py
+++ b/python/resdata/rft/rd_rft.py
@@ -61,13 +61,13 @@ class ResdataRFT:
                     i, j, k = grid_index - 1
                     self._cells.append(
                         ResdataRFTCell(
-                            i,
-                            j,
-                            k,
-                            depth[index],
-                            pressure[index],
-                            swat[index],
-                            sgas[index],
+                            int(i),
+                            int(j),
+                            int(k),
+                            _maybe_float(depth[index]),
+                            _maybe_float(pressure[index]),
+                            _maybe_float(swat[index]),
+                            _maybe_float(sgas[index]),
                         )
                     )
             case "PLT":
@@ -95,20 +95,20 @@ class ResdataRFT:
                     i, j, k = grid_index - 1
                     self._cells.append(
                         ResdataPLTCell(
-                            i,
-                            j,
-                            k,
-                            condepth[index],
-                            conpres[index],
-                            orat[index],
-                            grat[index],
-                            wrat[index],
-                            conn_start[index],
-                            conn_end[index],
-                            flowrate[index],
-                            oil_flowrate[index],
-                            gas_flowrate[index],
-                            water_flowrate[index],
+                            int(i),
+                            int(j),
+                            int(k),
+                            _maybe_float(condepth[index]),
+                            _maybe_float(conpres[index]),
+                            _maybe_float(orat[index]),
+                            _maybe_float(grat[index]),
+                            _maybe_float(wrat[index]),
+                            float(conn_start[index]),
+                            float(conn_end[index]),
+                            _maybe_float(flowrate[index]),
+                            _maybe_float(oil_flowrate[index]),
+                            _maybe_float(gas_flowrate[index]),
+                            _maybe_float(water_flowrate[index]),
                         )
                     )
                 if self._is_msw:
@@ -298,6 +298,10 @@ class ResdataRFTFile:
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(wells = {len(self)}) {id(self)}"
 
+def _maybe_float(f : Any | None) -> float | None:
+    if f is None:
+        return f
+    return float(f)
 
 monkey_the_camel(ResdataRFT, "getWellName", ResdataRFT.get_well_name)
 monkey_the_camel(ResdataRFT, "getDate", ResdataRFT.get_date)

--- a/python/tests/rd_tests/test_rft_file.py
+++ b/python/tests/rd_tests/test_rft_file.py
@@ -205,6 +205,9 @@ def test_that_reading_an_rft_cell_results_in_the_expected_values(tmp_path):
     assert node[1].soil == pytest.approx(0.4)
     assert node[0].get_ijk() == (0, 0, 0)
     assert node[1].get_ijk() == (1, 0, 1)
+    assert type(node[0].get_i()) == int
+    assert type(node[0].get_j()) == int
+    assert type(node[0].get_i()) == int
     assert node[0].depth == 20.0
     assert node[1].depth == 30.0
 
@@ -295,6 +298,7 @@ def test_that_reading_a_plt_cell_results_in_the_expected_values(tmp_path):
     assert node[1].get_ijk() == (1, 0, 1)
     assert node[0].depth == 2000.0
     assert node[1].depth == 3000.0
+    assert type(node[0].depth) == float
 
 
 def test_that_reading_a_plt_cell_with_zero_sum_conpres_uses_pressure(tmp_path):


### PR DESCRIPTION
The return types for these function changed in
3c463f4907b1fb6c1417dd83dd4e1797ea9f1c28 to 32-bit numpy counterparts. This subtypes correctly, but would probably break a lot of code. Therefore we explicitly cast.
