### PR TITLE
Solve pandas future warning

### DIFF
--- a/python/tests/rd_tests/test_sum.py
+++ b/python/tests/rd_tests/test_sum.py
@@ -752,12 +752,12 @@ def test_summary_to_pandas_frame(time_index_type):
     fopr = frame["FOPR"]
     fopt = frame["FOPT"]
 
-    assert fopr[0] == 0
-    assert fopr[-1] == 0
+    assert fopr.iloc[0] == 0
+    assert fopr.iloc[-1] == 0
 
-    assert fopt[0] == 0
-    assert fopt[0] == case.first_value("FOPT")
-    assert fopt[-1] == case.last_value("FOPT")
+    assert fopt.iloc[0] == 0
+    assert fopt.iloc[0] == case.first_value("FOPT")
+    assert fopt.iloc[-1] == case.last_value("FOPT")
 
     frame = case.pandas_frame()
     rows, columns = frame.shape


### PR DESCRIPTION
Solves:

FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
    assert fopt[-1] == case.last_value("FOPT")
    
only test that fails with pandas 3 rc
