### PR TITLE
Improve performance of view_summary

### DIFF
--- a/python/tests/test_view_summary.py
+++ b/python/tests/test_view_summary.py
@@ -859,3 +859,18 @@ def test_that_restart_and_base_times_are_concated(capsys):
         4,5.0,06/01/2014,5.6299e+16,5.6299e+16,-99.0
         """
     )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.timeout(10)
+def test_performance_with_many_keys(monkeypatch, benchmark):
+    dir = Path("subdir")
+    dir.mkdir()
+    monkeypatch.chdir(dir)
+    create_summary(case="TEST", summary_keys=[f"WWIT:N-{i}" for i in range(5000)])
+    monkeypatch.chdir("..")
+
+    def bench():
+        run(["summary.x", "-v", str(dir / "TEST"), "*"])
+
+    benchmark(bench)

--- a/python/view_summary/__main__.py
+++ b/python/view_summary/__main__.py
@@ -427,6 +427,7 @@ class Spec:
         # to preserve backwards-compatibility
         already_matched = set()
         new_matched_keywords = []
+        sort_until = None
         for pat in patterns:
             if "*" in pat:
                 for i in range(len(self.matched_keywords)):
@@ -436,9 +437,7 @@ class Spec:
                     if fnmatch.fnmatch(kw, pat):
                         new_matched_keywords.append((kw, self.keyword_indices[i]))
                         already_matched.add(kw)
-                        new_matched_keywords = natsorted(
-                            new_matched_keywords, key=lambda v: v[0]
-                        )
+                        sort_until = len(new_matched_keywords)
 
             else:
                 try:
@@ -450,6 +449,11 @@ class Spec:
                     logger.warning(
                         f"could not find variable: '{pat}' in summary file",
                     )
+        if sort_until is not None:
+            new_matched_keywords = (
+                natsorted(new_matched_keywords[:sort_until], key=lambda v: v[0])
+                + new_matched_keywords[sort_until:]
+            )
         self.matched_keywords = [k for k, _ in new_matched_keywords]
         self.keyword_indices = np.array(
             [i for _, i in new_matched_keywords], dtype=np.int64

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,6 @@
 pytest
+pytest-benchmark
+pytest-timeout
 hypothesis
 pydantic
 typing_extensions


### PR DESCRIPTION
After porting summary.x to python, performance for calling `summary.x CASE` for summaries with thousands of keys become unreasonably bad. This PR fixes that.
