### PR TITLE
Refactor fault block layer.cpp

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -170,7 +170,8 @@ add_executable(
   tests/testsuite.cpp
   tests/test_util.cpp
   tests/test_rd_region.cpp
-  tests/test_layer.cpp)
+  tests/test_layer.cpp
+  tests/test_fault_block_layer.cpp)
 target_compile_features(rd_test_suite PUBLIC cxx_std_17)
 target_include_directories(rd_test_suite
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/private-include)

--- a/lib/include/resdata/layer.hpp
+++ b/lib/include/resdata/layer.hpp
@@ -7,6 +7,7 @@
 #include <resdata/rd_grid.hpp>
 
 #ifdef __cplusplus
+#include <memory>
 extern "C" {
 #endif
 
@@ -70,4 +71,5 @@ UTIL_SAFE_CAST_HEADER(layer);
 #ifdef __cplusplus
 }
 #endif
+std::unique_ptr<layer_type, decltype(&layer_free)> make_layer(int, int);
 #endif

--- a/lib/resdata/fault_block_layer.cpp
+++ b/lib/resdata/fault_block_layer.cpp
@@ -59,22 +59,20 @@ fault_block_type *fault_block_layer_add_block(fault_block_layer_type *layer,
 
 void fault_block_layer_scan_layer(fault_block_layer_type *fault_layer,
                                   layer_type *layer) {
-    int i, j;
     int_vector_type *i_list = int_vector_alloc(0, 0);
     int_vector_type *j_list = int_vector_alloc(0, 0);
 
-    for (j = 0; j < layer_get_ny(layer); j++) {
-        for (i = 0; i < layer_get_nx(layer); i++) {
+    for (int j = 0; j < layer_get_ny(layer); j++) {
+        for (int i = 0; i < layer_get_nx(layer); i++) {
             int cell_value = layer_iget_cell_value(layer, i, j);
             if (cell_value != 0) {
                 layer_trace_block_content(layer, true, i, j, cell_value, i_list,
                                           j_list);
                 {
-                    int c;
                     int block_id = fault_block_layer_get_next_id(fault_layer);
                     fault_block_type *fault_block =
                         fault_block_layer_add_block(fault_layer, block_id);
-                    for (c = 0; c < int_vector_size(i_list); c++)
+                    for (int c = 0; c < int_vector_size(i_list); c++)
                         fault_block_add_cell(fault_block,
                                              int_vector_iget(i_list, c),
                                              int_vector_iget(j_list, c));
@@ -112,13 +110,12 @@ bool fault_block_layer_scan_kw(fault_block_layer_type *layer,
     else if (!rd_type_is_int(rd_kw_get_data_type(fault_block_kw)))
         return false;
     else {
-        int i, j;
         int max_block_id = 0;
         layer_type *work_layer = layer_alloc(rd_grid_get_nx(layer->grid),
                                              rd_grid_get_ny(layer->grid));
 
-        for (j = 0; j < rd_grid_get_ny(layer->grid); j++) {
-            for (i = 0; i < rd_grid_get_nx(layer->grid); i++) {
+        for (int j = 0; j < rd_grid_get_ny(layer->grid); j++) {
+            for (int i = 0; i < rd_grid_get_nx(layer->grid); i++) {
                 int g = rd_grid_get_global_index3(layer->grid, i, j, layer->k);
                 int block_id = rd_kw_iget_int(fault_block_kw, g);
 
@@ -151,10 +148,8 @@ bool fault_block_layer_load_kw(fault_block_layer_type *layer,
     else if (!rd_type_is_int(rd_kw_get_data_type(fault_block_kw)))
         return false;
     else {
-        int i, j;
-
-        for (j = 0; j < rd_grid_get_ny(layer->grid); j++) {
-            for (i = 0; i < rd_grid_get_nx(layer->grid); i++) {
+        for (int j = 0; j < rd_grid_get_ny(layer->grid); j++) {
+            for (int i = 0; i < rd_grid_get_nx(layer->grid); i++) {
                 int g = rd_grid_get_global_index3(layer->grid, i, j, layer->k);
                 int block_id = rd_kw_iget_int(fault_block_kw, g);
                 if (block_id > 0) {
@@ -220,17 +215,13 @@ void fault_block_layer_del_block(fault_block_layer_type *layer, int block_id) {
 
         int_vector_iset(layer->block_map, block_id, -1);
         vector_idel(layer->blocks, storage_index);
-        {
-            int index;
-
-            for (index = 0; index < int_vector_size(layer->block_map);
-                 index++) {
-                int current_storage_index =
-                    int_vector_iget(layer->block_map, index);
-                if (current_storage_index > storage_index)
-                    int_vector_iset(layer->block_map, index,
-                                    current_storage_index - 1);
-            }
+        for (int index = 0; index < int_vector_size(layer->block_map);
+             index++) {
+            int current_storage_index =
+                int_vector_iget(layer->block_map, index);
+            if (current_storage_index > storage_index)
+                int_vector_iset(layer->block_map, index,
+                                current_storage_index - 1);
         }
     }
 }
@@ -282,10 +273,8 @@ bool fault_block_layer_export(const fault_block_layer_type *layer,
     if (rd_type_is_int(rd_kw_get_data_type(faultblock_kw)) &&
         (rd_kw_get_size(faultblock_kw) ==
          rd_grid_get_global_size(layer->grid))) {
-        int i, j;
-
-        for (j = 0; j < rd_grid_get_ny(layer->grid); j++) {
-            for (i = 0; i < rd_grid_get_nx(layer->grid); i++) {
+        for (int j = 0; j < rd_grid_get_ny(layer->grid); j++) {
+            for (int i = 0; i < rd_grid_get_nx(layer->grid); i++) {
                 int g = rd_grid_get_global_index3(layer->grid, i, j, layer->k);
                 int cell_value = layer_iget_cell_value(layer->layer, i, j);
                 rd_kw_iset_int(faultblock_kw, g, cell_value);

--- a/lib/resdata/fault_block_layer.cpp
+++ b/lib/resdata/fault_block_layer.cpp
@@ -10,6 +10,7 @@
 #include <resdata/layer.hpp>
 
 #include <memory>
+#include <vector>
 
 #define FAULT_BLOCK_LAYER_ID 2297476
 
@@ -35,17 +36,17 @@ void fault_block_free(fault_block_type *block, int block_id);
 struct fault_block_layer_struct {
     UTIL_TYPE_ID_DECLARATION;
     const rd_grid_type *grid;
-    int_vector_type *block_map;
+    std::vector<int> block_map;
     layer_type *layer;
     int k;
     vector_type *blocks;
 
     [[nodiscard]] int get_block(int index) const {
-        if (index >= int_vector_size(block_map))
-            return int_vector_get_default(block_map);
+        if (index >= static_cast<int>(block_map.size()))
+            return -1;
         else {
             if (index >= 0)
-                return int_vector_iget(block_map, index);
+                return block_map[index];
             else {
                 util_abort("%s: index:%d is invalid - only accepts positive "
                            "indices.\n",
@@ -63,9 +64,9 @@ fault_block_type *fault_block_layer_add_block(fault_block_layer_type *layer,
         fault_block_type *block = fault_block_alloc(layer, block_id);
         int storage_index = vector_get_size(layer->blocks);
 
-        if (block_id >= int_vector_size(layer->block_map))
-            int_vector_resize(layer->block_map, block_id + 1, -1);
-        int_vector_iset(layer->block_map, block_id, storage_index);
+        if (block_id >= static_cast<int>(layer->block_map.size()))
+            layer->block_map.resize(block_id + 1, -1);
+        layer->block_map[block_id] = storage_index;
         vector_append_owned_ref(layer->blocks, block, fault_block_free__);
 
         return block;
@@ -184,12 +185,11 @@ fault_block_layer_type *fault_block_layer_alloc(const rd_grid_type *grid,
     if ((k < 0) || (k >= rd_grid_get_nz(grid)))
         return NULL;
     else {
-        fault_block_layer_type *layer =
-            (fault_block_layer_type *)util_malloc(sizeof *layer);
+        auto layer = new fault_block_layer_type;
         UTIL_TYPE_ID_INIT(layer, FAULT_BLOCK_LAYER_ID);
         layer->grid = grid;
         layer->k = k;
-        layer->block_map = int_vector_alloc(0, -1);
+        layer->block_map = std::vector<int>(0);
         layer->blocks = vector_alloc_new();
         layer->layer = layer_alloc(rd_grid_get_nx(grid), rd_grid_get_ny(grid));
 
@@ -225,15 +225,12 @@ void fault_block_layer_del_block(fault_block_layer_type *layer, int block_id) {
     int storage_index = layer->get_block(block_id);
     if (storage_index >= 0) {
 
-        int_vector_iset(layer->block_map, block_id, -1);
+        layer->block_map.at(block_id) = -1;
         vector_idel(layer->blocks, storage_index);
-        for (int index = 0; index < int_vector_size(layer->block_map);
-             index++) {
-            int current_storage_index =
-                int_vector_iget(layer->block_map, index);
+        for (int index = 0; index < layer->block_map.size(); index++) {
+            int current_storage_index = layer->block_map.at(index);
             if (current_storage_index > storage_index)
-                int_vector_iset(layer->block_map, index,
-                                current_storage_index - 1);
+                layer->block_map.at(index) = current_storage_index - 1;
         }
     }
 }
@@ -247,14 +244,14 @@ bool fault_block_layer_has_block(const fault_block_layer_type *layer,
 }
 
 int fault_block_layer_get_max_id(const fault_block_layer_type *layer) {
-    return layer->block_map.size() - 1;
+    return static_cast<int>(layer->block_map.size()) - 1;
 }
 
 int fault_block_layer_get_next_id(const fault_block_layer_type *layer) {
     if (layer->block_map.size() == 0)
         return 1;
     else
-        return int_vector_size(layer->block_map);
+        return static_cast<int>(layer->block_map.size());
 }
 
 int fault_block_layer_get_size(const fault_block_layer_type *layer) {
@@ -266,10 +263,9 @@ int fault_block_layer_get_k(const fault_block_layer_type *layer) {
 }
 
 void fault_block_layer_free(fault_block_layer_type *layer) {
-    int_vector_free(layer->block_map);
     vector_free(layer->blocks);
     layer_free(layer->layer);
-    free(layer);
+    delete layer;
 }
 
 void fault_block_layer_insert_block_content(fault_block_layer_type *layer,

--- a/lib/resdata/fault_block_layer.cpp
+++ b/lib/resdata/fault_block_layer.cpp
@@ -39,13 +39,27 @@ struct fault_block_layer_struct {
     layer_type *layer;
     int k;
     vector_type *blocks;
+
+    [[nodiscard]] int get_block(int index) const {
+        if (index >= int_vector_size(block_map))
+            return int_vector_get_default(block_map);
+        else {
+            if (index >= 0)
+                return int_vector_iget(block_map, index);
+            else {
+                util_abort("%s: index:%d is invalid - only accepts positive "
+                           "indices.\n",
+                           __func__, index);
+            }
+        }
+    }
 };
 
 UTIL_IS_INSTANCE_FUNCTION(fault_block_layer, FAULT_BLOCK_LAYER_ID);
 
 fault_block_type *fault_block_layer_add_block(fault_block_layer_type *layer,
                                               int block_id) {
-    if (int_vector_safe_iget(layer->block_map, block_id) < 0) {
+    if (layer->get_block(block_id) < 0) {
         fault_block_type *block = fault_block_alloc(layer, block_id);
         int storage_index = vector_get_size(layer->blocks);
 
@@ -191,7 +205,7 @@ fault_block_layer_iget_block(const fault_block_layer_type *layer,
 
 fault_block_type *
 fault_block_layer_get_block(const fault_block_layer_type *layer, int block_id) {
-    int storage_index = int_vector_safe_iget(layer->block_map, block_id);
+    int storage_index = layer->get_block(block_id);
     if (storage_index < 0)
         return NULL;
     else
@@ -200,7 +214,7 @@ fault_block_layer_get_block(const fault_block_layer_type *layer, int block_id) {
 
 fault_block_type *
 fault_block_layer_safe_get_block(fault_block_layer_type *layer, int block_id) {
-    int storage_index = int_vector_safe_iget(layer->block_map, block_id);
+    int storage_index = layer->get_block(block_id);
     if (storage_index < 0)
         return fault_block_layer_add_block(layer, block_id);
     else
@@ -208,7 +222,7 @@ fault_block_layer_safe_get_block(fault_block_layer_type *layer, int block_id) {
 }
 
 void fault_block_layer_del_block(fault_block_layer_type *layer, int block_id) {
-    int storage_index = int_vector_safe_iget(layer->block_map, block_id);
+    int storage_index = layer->get_block(block_id);
     if (storage_index >= 0) {
 
         int_vector_iset(layer->block_map, block_id, -1);
@@ -226,18 +240,18 @@ void fault_block_layer_del_block(fault_block_layer_type *layer, int block_id) {
 
 bool fault_block_layer_has_block(const fault_block_layer_type *layer,
                                  int block_id) {
-    if (int_vector_safe_iget(layer->block_map, block_id) >= 0)
+    if (layer->get_block(block_id) >= 0)
         return true;
     else
         return false;
 }
 
 int fault_block_layer_get_max_id(const fault_block_layer_type *layer) {
-    return int_vector_size(layer->block_map) - 1;
+    return layer->block_map.size() - 1;
 }
 
 int fault_block_layer_get_next_id(const fault_block_layer_type *layer) {
-    if (int_vector_size(layer->block_map) == 0)
+    if (layer->block_map.size() == 0)
         return 1;
     else
         return int_vector_size(layer->block_map);

--- a/lib/resdata/fault_block_layer.cpp
+++ b/lib/resdata/fault_block_layer.cpp
@@ -61,30 +61,27 @@ fault_block_type *fault_block_layer_add_block(fault_block_layer_type *layer,
 
 void fault_block_layer_scan_layer(fault_block_layer_type *fault_layer,
                                   layer_type *layer) {
-    int_vector_type *i_list = int_vector_alloc(0, 0);
-    int_vector_type *j_list = int_vector_alloc(0, 0);
+    auto i_list = make_int_vector(0, 0);
+    auto j_list = make_int_vector(0, 0);
 
     for (int j = 0; j < layer_get_ny(layer); j++) {
         for (int i = 0; i < layer_get_nx(layer); i++) {
             int cell_value = layer_iget_cell_value(layer, i, j);
             if (cell_value != 0) {
-                layer_trace_block_content(layer, true, i, j, cell_value, i_list,
-                                          j_list);
+                layer_trace_block_content(layer, true, i, j, cell_value,
+                                          i_list.get(), j_list.get());
                 {
                     int block_id = fault_block_layer_get_next_id(fault_layer);
                     fault_block_type *fault_block =
                         fault_block_layer_add_block(fault_layer, block_id);
-                    for (int c = 0; c < int_vector_size(i_list); c++)
+                    for (int c = 0; c < int_vector_size(i_list.get()); c++)
                         fault_block_add_cell(fault_block,
-                                             int_vector_iget(i_list, c),
-                                             int_vector_iget(j_list, c));
+                                             int_vector_iget(i_list.get(), c),
+                                             int_vector_iget(j_list.get(), c));
                 }
             }
         }
     }
-
-    int_vector_free(i_list);
-    int_vector_free(j_list);
 }
 
 /*

--- a/lib/resdata/fault_block_layer.cpp
+++ b/lib/resdata/fault_block_layer.cpp
@@ -226,13 +226,11 @@ fault_block_layer_safe_get_block(fault_block_layer_type *layer, int block_id) {
 void fault_block_layer_del_block(fault_block_layer_type *layer, int block_id) {
     int storage_index = layer->get_block(block_id);
     if (storage_index >= 0) {
-
         layer->block_map.at(block_id) = -1;
         layer->blocks.erase(layer->blocks.begin() + storage_index);
-        for (int index = 0; index < layer->block_map.size(); index++) {
-            int current_storage_index = layer->block_map.at(index);
-            if (current_storage_index > storage_index)
-                layer->block_map.at(index) = current_storage_index - 1;
+        for (int &index : layer->block_map) {
+            if (index > storage_index)
+                index -= 1;
         }
     }
 }

--- a/lib/resdata/fault_block_layer.cpp
+++ b/lib/resdata/fault_block_layer.cpp
@@ -31,7 +31,8 @@
 
 fault_block_type *fault_block_alloc(const fault_block_layer_type *parent_layer,
                                     int block_id);
-void fault_block_free(fault_block_type *block, int block_id);
+void fault_block_free(fault_block_type *block);
+
 
 struct fault_block_layer_struct {
     UTIL_TYPE_ID_DECLARATION;

--- a/lib/resdata/fault_block_layer.cpp
+++ b/lib/resdata/fault_block_layer.cpp
@@ -32,7 +32,8 @@
 fault_block_type *fault_block_alloc(const fault_block_layer_type *parent_layer,
                                     int block_id);
 void fault_block_free(fault_block_type *block);
-
+using block_ptr =
+    std::unique_ptr<fault_block_type, decltype(&fault_block_free)>;
 
 struct fault_block_layer_struct {
     UTIL_TYPE_ID_DECLARATION;
@@ -40,7 +41,7 @@ struct fault_block_layer_struct {
     std::vector<int> block_map;
     layer_type *layer;
     int k;
-    vector_type *blocks;
+    std::vector<block_ptr> blocks;
 
     [[nodiscard]] int get_block(int index) const {
         if (index >= static_cast<int>(block_map.size()))
@@ -63,12 +64,12 @@ fault_block_type *fault_block_layer_add_block(fault_block_layer_type *layer,
                                               int block_id) {
     if (layer->get_block(block_id) < 0) {
         fault_block_type *block = fault_block_alloc(layer, block_id);
-        int storage_index = vector_get_size(layer->blocks);
+        int storage_index = layer->blocks.size();
 
         if (block_id >= static_cast<int>(layer->block_map.size()))
             layer->block_map.resize(block_id + 1, -1);
         layer->block_map[block_id] = storage_index;
-        vector_append_owned_ref(layer->blocks, block, fault_block_free__);
+        layer->blocks.emplace_back(block, &fault_block_free);
 
         return block;
     } else
@@ -191,7 +192,7 @@ fault_block_layer_type *fault_block_layer_alloc(const rd_grid_type *grid,
         layer->grid = grid;
         layer->k = k;
         layer->block_map = std::vector<int>(0);
-        layer->blocks = vector_alloc_new();
+        layer->blocks = std::vector<block_ptr>();
         layer->layer = layer_alloc(rd_grid_get_nx(grid), rd_grid_get_ny(grid));
 
         return layer;
@@ -201,7 +202,7 @@ fault_block_layer_type *fault_block_layer_alloc(const rd_grid_type *grid,
 fault_block_type *
 fault_block_layer_iget_block(const fault_block_layer_type *layer,
                              int storage_index) {
-    return (fault_block_type *)vector_iget(layer->blocks, storage_index);
+    return layer->blocks.at(storage_index).get();
 }
 
 fault_block_type *
@@ -210,7 +211,7 @@ fault_block_layer_get_block(const fault_block_layer_type *layer, int block_id) {
     if (storage_index < 0)
         return NULL;
     else
-        return (fault_block_type *)vector_iget(layer->blocks, storage_index);
+        return layer->blocks.at(storage_index).get();
 }
 
 fault_block_type *
@@ -219,7 +220,7 @@ fault_block_layer_safe_get_block(fault_block_layer_type *layer, int block_id) {
     if (storage_index < 0)
         return fault_block_layer_add_block(layer, block_id);
     else
-        return (fault_block_type *)vector_iget(layer->blocks, storage_index);
+        return layer->blocks.at(storage_index).get();
 }
 
 void fault_block_layer_del_block(fault_block_layer_type *layer, int block_id) {
@@ -227,7 +228,7 @@ void fault_block_layer_del_block(fault_block_layer_type *layer, int block_id) {
     if (storage_index >= 0) {
 
         layer->block_map.at(block_id) = -1;
-        vector_idel(layer->blocks, storage_index);
+        layer->blocks.erase(layer->blocks.begin() + storage_index);
         for (int index = 0; index < layer->block_map.size(); index++) {
             int current_storage_index = layer->block_map.at(index);
             if (current_storage_index > storage_index)
@@ -256,7 +257,7 @@ int fault_block_layer_get_next_id(const fault_block_layer_type *layer) {
 }
 
 int fault_block_layer_get_size(const fault_block_layer_type *layer) {
-    return vector_get_size(layer->blocks);
+    return static_cast<int>(layer->blocks.size());
 }
 
 int fault_block_layer_get_k(const fault_block_layer_type *layer) {
@@ -264,7 +265,6 @@ int fault_block_layer_get_k(const fault_block_layer_type *layer) {
 }
 
 void fault_block_layer_free(fault_block_layer_type *layer) {
-    vector_free(layer->blocks);
     layer_free(layer->layer);
     delete layer;
 }

--- a/lib/resdata/fault_block_layer.cpp
+++ b/lib/resdata/fault_block_layer.cpp
@@ -9,6 +9,8 @@
 #include <resdata/fault_block.hpp>
 #include <resdata/layer.hpp>
 
+#include <memory>
+
 #define FAULT_BLOCK_LAYER_ID 2297476
 
 /*
@@ -111,8 +113,10 @@ bool fault_block_layer_scan_kw(fault_block_layer_type *layer,
         return false;
     else {
         int max_block_id = 0;
-        layer_type *work_layer = layer_alloc(rd_grid_get_nx(layer->grid),
-                                             rd_grid_get_ny(layer->grid));
+        std::unique_ptr<layer_type, decltype(&layer_free)> work_layer(
+            layer_alloc(rd_grid_get_nx(layer->grid),
+                        rd_grid_get_ny(layer->grid)),
+            layer_free);
 
         for (int j = 0; j < rd_grid_get_ny(layer->grid); j++) {
             for (int i = 0; i < rd_grid_get_nx(layer->grid); i++) {
@@ -120,17 +124,16 @@ bool fault_block_layer_scan_kw(fault_block_layer_type *layer,
                 int block_id = rd_kw_iget_int(fault_block_kw, g);
 
                 if (block_id > 0) {
-                    layer_iset_cell_value(work_layer, i, j, block_id);
+                    layer_iset_cell_value(work_layer.get(), i, j, block_id);
                     max_block_id = util_int_max(block_id, max_block_id);
                 }
             }
         }
 
         if (assign_zero)
-            layer_replace_cell_values(work_layer, 0, max_block_id + 1);
+            layer_replace_cell_values(work_layer.get(), 0, max_block_id + 1);
 
-        fault_block_layer_scan_layer(layer, work_layer);
-        layer_free(work_layer);
+        fault_block_layer_scan_layer(layer, work_layer.get());
         return true;
     }
 }

--- a/lib/resdata/fault_block_layer.cpp
+++ b/lib/resdata/fault_block_layer.cpp
@@ -113,10 +113,8 @@ bool fault_block_layer_scan_kw(fault_block_layer_type *layer,
         return false;
     else {
         int max_block_id = 0;
-        std::unique_ptr<layer_type, decltype(&layer_free)> work_layer(
-            layer_alloc(rd_grid_get_nx(layer->grid),
-                        rd_grid_get_ny(layer->grid)),
-            layer_free);
+        auto work_layer = make_layer(rd_grid_get_nx(layer->grid),
+                                     rd_grid_get_ny(layer->grid));
 
         for (int j = 0; j < rd_grid_get_ny(layer->grid); j++) {
             for (int i = 0; i < rd_grid_get_nx(layer->grid); i++) {

--- a/lib/resdata/layer.cpp
+++ b/lib/resdata/layer.cpp
@@ -651,3 +651,7 @@ void layer_update_active(layer_type *layer, const rd_grid_type *grid, int k) {
         }
     }
 }
+
+std::unique_ptr<layer_type, decltype(&layer_free)> make_layer(int nx, int ny) {
+    return {layer_alloc(nx, ny), layer_free};
+}

--- a/lib/tests/test_fault_block_layer.cpp
+++ b/lib/tests/test_fault_block_layer.cpp
@@ -1,0 +1,492 @@
+#include <resdata/fault_block_layer.hpp>
+#include <resdata/fault_block.hpp>
+#include <resdata/rd_grid.hpp>
+#include <resdata/rd_kw.hpp>
+#include <resdata/layer.hpp>
+
+#include <memory>
+
+#include <catch2/catch.hpp>
+
+static std::unique_ptr<rd_grid_type, decltype(&rd_grid_free)>
+make_grid(int nx, int ny, int nz) {
+    return {rd_grid_alloc_rectangular(nx, ny, nz, 1, 1, 1, nullptr),
+            rd_grid_free};
+}
+
+static std::unique_ptr<fault_block_layer_type,
+                       decltype(&fault_block_layer_free)>
+make_fb_layer(const rd_grid_type *grid, int k) {
+    return {fault_block_layer_alloc(grid, k), fault_block_layer_free};
+}
+
+static std::unique_ptr<rd_kw_type, decltype(&rd_kw_free)>
+make_kw(const char *header, int size, rd_data_type data_type) {
+    return {rd_kw_alloc(header, size, data_type), rd_kw_free};
+}
+
+TEST_CASE("fault_block_layer alloc errors", "[fault_block_layer]") {
+    GIVEN("A 5x5x3 grid") {
+        auto grid = make_grid(5, 5, 3);
+        WHEN("Allocating with k out of range") {
+            THEN("Returns NULL for negative k") {
+                REQUIRE(fault_block_layer_alloc(grid.get(), -1) == nullptr);
+            }
+
+            THEN("Returns NULL for k >= nz") {
+                REQUIRE(fault_block_layer_alloc(grid.get(), 3) == nullptr);
+            }
+        }
+    }
+}
+
+TEST_CASE("fault_block_layer methods", "[fault_block_layer]") {
+    GIVEN("A fault_block_layer") {
+        int nx = 5, ny = 5, nz = 3;
+        auto grid = make_grid(nx, ny, nz);
+        auto idx = [&](int i, int j) {
+            return rd_grid_get_global_index3(grid.get(), i, j, 0);
+        };
+        auto layer = make_fb_layer(grid.get(), 0);
+        layer_type *geo_layer = fault_block_layer_get_layer(layer.get());
+
+        THEN("The k value matches") {
+            REQUIRE(fault_block_layer_get_k(layer.get()) == 0);
+        }
+        THEN("The grid is the same") {
+            REQUIRE(fault_block_layer_get_grid(layer.get()) == grid.get());
+        }
+        THEN("The layer is initially empty") {
+            REQUIRE(fault_block_layer_get_size(layer.get()) == 0);
+        }
+        THEN("get_next_id returns 1 when empty") {
+            REQUIRE(fault_block_layer_get_next_id(layer.get()) == 1);
+        }
+        THEN("get_max_id returns -1 when empty") {
+            REQUIRE(fault_block_layer_get_max_id(layer.get()) == -1);
+        }
+        THEN("get_layer returns a non-null layer") {
+            REQUIRE(fault_block_layer_get_layer(layer.get()) != nullptr);
+        }
+
+        WHEN("A block with id 4 is added") {
+            fault_block_layer_add_block(layer.get(), 4);
+
+            THEN("get_max_id returns 4") {
+                REQUIRE(fault_block_layer_get_max_id(layer.get()) == 4);
+            }
+
+            THEN("get_next_id returns 5") {
+                REQUIRE(fault_block_layer_get_next_id(layer.get()) == 5);
+            }
+        }
+
+        WHEN("Adding a block") {
+            fault_block_type *block =
+                fault_block_layer_add_block(layer.get(), 3);
+
+            THEN("The layer has one block") {
+                REQUIRE(fault_block_layer_get_size(layer.get()) == 1);
+            }
+
+            THEN("has_block returns true for that id") {
+                REQUIRE(fault_block_layer_has_block(layer.get(), 3));
+            }
+
+            THEN("has_block returns false for a different id") {
+                REQUIRE_FALSE(fault_block_layer_has_block(layer.get(), 99));
+            }
+
+            THEN("get_block returns the same block") {
+                REQUIRE(fault_block_layer_get_block(layer.get(), 3) == block);
+            }
+
+            THEN("iget_block returns the block at storage index 0") {
+                REQUIRE(fault_block_layer_iget_block(layer.get(), 0) == block);
+            }
+
+            THEN("get_block_id matches") {
+                REQUIRE(fault_block_get_id(block) == 3);
+            }
+        }
+
+        WHEN("Adding the same block id twice") {
+            fault_block_layer_add_block(layer.get(), 5);
+            fault_block_type *dup = fault_block_layer_add_block(layer.get(), 5);
+
+            THEN("The second add returns NULL") { REQUIRE(dup == nullptr); }
+
+            THEN("The layer still has one block") {
+                REQUIRE(fault_block_layer_get_size(layer.get()) == 1);
+            }
+        }
+
+        WHEN("safe_get_block is called for a non-existing id") {
+            fault_block_type *block =
+                fault_block_layer_safe_get_block(layer.get(), 7);
+
+            THEN("The block is created and returned") {
+                REQUIRE(block != nullptr);
+                REQUIRE(fault_block_layer_has_block(layer.get(), 7));
+            }
+        }
+
+        WHEN("safe_get_block is called for an existing id") {
+            fault_block_layer_add_block(layer.get(), 2);
+            fault_block_type *block =
+                fault_block_layer_safe_get_block(layer.get(), 2);
+
+            THEN("The existing block is returned") {
+                REQUIRE(block != nullptr);
+                REQUIRE(fault_block_get_id(block) == 2);
+                REQUIRE(fault_block_layer_get_size(layer.get()) == 1);
+            }
+        }
+        AND_GIVEN("Two blocks in the layer") {
+            fault_block_layer_add_block(layer.get(), 1);
+            fault_block_layer_add_block(layer.get(), 2);
+
+            WHEN("Deleting one of the blocks") {
+                fault_block_layer_del_block(layer.get(), 1);
+
+                THEN("The layer has one block") {
+                    REQUIRE(fault_block_layer_get_size(layer.get()) == 1);
+                }
+
+                THEN("has_block returns false for the deleted id") {
+                    REQUIRE_FALSE(fault_block_layer_has_block(layer.get(), 1));
+                }
+
+                THEN("has_block still returns true for the remaining block") {
+                    REQUIRE(fault_block_layer_has_block(layer.get(), 2));
+                }
+            }
+
+            WHEN("Deleting a non-existing block") {
+                fault_block_layer_del_block(layer.get(), 99);
+
+                THEN("The layer still has two blocks") {
+                    REQUIRE(fault_block_layer_get_size(layer.get()) == 2);
+                }
+            }
+        }
+
+        AND_GIVEN("A fault block keyword") {
+            /*
+             * Layout of the layer (j outer, i inner):
+             *   1 1 0 0 0
+             *   0 2 2 0 0
+             *   0 0 0 0 0
+             *   0 0 0 0 0
+             *   0 0 0 0 0
+             */
+            auto kw = make_kw("FAULTBLK", nx * ny * nz, RD_INT);
+            rd_kw_iset_int(kw.get(), idx(0, 0), 1);
+            rd_kw_iset_int(kw.get(), idx(1, 0), 1);
+            rd_kw_iset_int(kw.get(), idx(1, 1), 2);
+            rd_kw_iset_int(kw.get(),
+                           rd_grid_get_global_index3(grid.get(), 2, 1, 0), 2);
+
+            WHEN("scan_kw is called") {
+                bool ok = fault_block_layer_scan_kw(layer.get(), kw.get());
+
+                THEN("scan_kw returns true") { REQUIRE(ok); }
+
+                THEN("Three blocks are created (two non-zero ids plus one "
+                     "for zero cells)") {
+                    REQUIRE(fault_block_layer_get_size(layer.get()) == 3);
+                }
+                THEN("The first block contains the 1 cells") {
+                    const fault_block_type *block =
+                        fault_block_layer_iget_block(layer.get(), 0);
+                    REQUIRE(fault_block_get_size(block) == 2);
+                    REQUIRE(layer_iget_cell_value(geo_layer, 0, 0) == 1);
+                    REQUIRE(layer_iget_cell_value(geo_layer, 1, 0) == 1);
+                }
+                THEN("The second block contains the 0 cells") {
+                    const fault_block_type *block =
+                        fault_block_layer_iget_block(layer.get(), 1);
+                    REQUIRE(fault_block_get_size(block) == 21);
+                    REQUIRE(layer_iget_cell_value(geo_layer, 3, 3) == 2);
+                }
+                THEN("The third block contains the 2 cells") {
+                    const fault_block_type *block =
+                        fault_block_layer_iget_block(layer.get(), 2);
+                    REQUIRE(fault_block_get_size(block) == 2);
+                    REQUIRE(layer_iget_cell_value(geo_layer, 1, 1) == 3);
+                    REQUIRE(layer_iget_cell_value(geo_layer, 2, 1) == 3);
+                }
+            }
+
+            WHEN("load_kw is called") {
+                bool ok = fault_block_layer_load_kw(layer.get(), kw.get());
+
+                THEN("load_kw returns true") { REQUIRE(ok); }
+
+                THEN("Two blocks are created (only non-zero ids)") {
+                    REQUIRE(fault_block_layer_get_size(layer.get()) == 2);
+                }
+                THEN("The first block contains the 1 cells") {
+                    const fault_block_type *block =
+                        fault_block_layer_iget_block(layer.get(), 0);
+                    REQUIRE(fault_block_get_size(block) == 2);
+                    REQUIRE(layer_iget_cell_value(geo_layer, 0, 0) == 1);
+                    REQUIRE(layer_iget_cell_value(geo_layer, 1, 0) == 1);
+                }
+                THEN("The second block contains the 2 cells") {
+                    const fault_block_type *block =
+                        fault_block_layer_iget_block(layer.get(), 1);
+                    REQUIRE(fault_block_get_size(block) == 2);
+                    REQUIRE(layer_iget_cell_value(geo_layer, 1, 1) == 2);
+                    REQUIRE(layer_iget_cell_value(geo_layer, 2, 1) == 2);
+                }
+                THEN("Zero cells are not assigned a block") {
+                    REQUIRE(layer_iget_cell_value(geo_layer, 3, 3) == 0);
+                }
+            }
+            WHEN("Exporting to a correctly sized integer keyword") {
+                fault_block_layer_load_kw(layer.get(), kw.get());
+                auto out_kw = make_kw("OUT", nx * ny * nz, RD_INT);
+                bool ok = fault_block_layer_export(layer.get(), out_kw.get());
+
+                THEN("export returns true") { REQUIRE(ok); }
+
+                THEN("exported cell values match the original keyword") {
+                    REQUIRE(rd_kw_iget_int(out_kw.get(), idx(0, 0)) == 1);
+                    REQUIRE(rd_kw_iget_int(out_kw.get(), idx(1, 0)) == 1);
+                    REQUIRE(rd_kw_iget_int(out_kw.get(), idx(1, 1)) == 2);
+                    REQUIRE(rd_kw_iget_int(out_kw.get(), idx(2, 1)) == 2);
+                    REQUIRE(rd_kw_iget_int(out_kw.get(), idx(2, 0)) == 0);
+                }
+            }
+
+            WHEN("Exporting to a keyword with wrong size") {
+                auto bad_kw = make_kw("OUT", 1, RD_INT);
+                THEN("export returns false") {
+                    REQUIRE_FALSE(
+                        fault_block_layer_export(layer.get(), bad_kw.get()));
+                }
+            }
+
+            WHEN("Exporting to a float keyword") {
+                auto float_kw = make_kw("OUT", nx * ny * nz, RD_FLOAT);
+                THEN("export returns false") {
+                    REQUIRE_FALSE(
+                        fault_block_layer_export(layer.get(), float_kw.get()));
+                }
+            }
+        }
+        WHEN("scan_kw is called with non-integer keyword") {
+            auto float_kw = make_kw("FAULTBLK", nx * ny * nz, RD_FLOAT);
+            THEN("scan_kw returns false") {
+                REQUIRE_FALSE(
+                    fault_block_layer_scan_kw(layer.get(), float_kw.get()));
+            }
+        }
+        WHEN("scan_kw is called with wrong size keyword") {
+            auto bad_kw = make_kw("FAULTBLK", 1, RD_INT);
+            THEN("scan_kw returns false") {
+                REQUIRE_FALSE(
+                    fault_block_layer_scan_kw(layer.get(), bad_kw.get()));
+            }
+        }
+
+        WHEN("load_kw is called with wrong size keyword") {
+            auto bad_kw = make_kw("FAULTBLK", 1, RD_INT);
+            THEN("load_kw returns false") {
+                REQUIRE_FALSE(
+                    fault_block_layer_load_kw(layer.get(), bad_kw.get()));
+            }
+        }
+        WHEN("load_kw is called with non-integer keyword") {
+            auto float_kw = make_kw("FAULTBLK", nx * ny * nz, RD_FLOAT);
+            THEN("load_kw returns false") {
+                REQUIRE_FALSE(
+                    fault_block_layer_load_kw(layer.get(), float_kw.get()));
+            }
+        }
+        AND_GIVEN("A layer with block containing two cells") {
+            fault_block_type *src_block =
+                fault_block_layer_add_block(layer.get(), 1);
+            fault_block_add_cell(src_block, 0, 0);
+            fault_block_add_cell(src_block, 1, 0);
+
+            WHEN("insert_block_content is called on another layer") {
+                auto dst_layer = make_fb_layer(grid.get(), 0);
+                fault_block_layer_insert_block_content(dst_layer.get(),
+                                                       src_block);
+
+                THEN("The destination layer has one block") {
+                    REQUIRE(fault_block_layer_get_size(dst_layer.get()) == 1);
+                }
+
+                THEN("The inserted block has two cells") {
+                    fault_block_type *inserted =
+                        fault_block_layer_iget_block(dst_layer.get(), 0);
+                    REQUIRE(fault_block_get_size(inserted) == 2);
+                }
+            }
+        }
+        AND_GIVEN("blocks at ids 1 and 10") {
+            fault_block_layer_add_block(layer.get(), 1);
+            fault_block_layer_add_block(layer.get(), 10);
+
+            THEN("get_size is 2") {
+                REQUIRE(fault_block_layer_get_size(layer.get()) == 2);
+            }
+
+            THEN("has_block is false for an intermediate id") {
+                REQUIRE_FALSE(fault_block_layer_has_block(layer.get(), 5));
+            }
+
+            THEN("get_block returns NULL for an intermediate id") {
+                REQUIRE(fault_block_layer_get_block(layer.get(), 5) == nullptr);
+            }
+
+            THEN("get_max_id is 10") {
+                REQUIRE(fault_block_layer_get_max_id(layer.get()) == 10);
+            }
+        }
+        AND_GIVEN("three blocks at ids 1, 2, 3") {
+            fault_block_layer_add_block(layer.get(), 1);
+            fault_block_layer_add_block(layer.get(), 2);
+            fault_block_layer_add_block(layer.get(), 3);
+
+            WHEN("The first block (id=1) is deleted") {
+                fault_block_layer_del_block(layer.get(), 1);
+
+                THEN("get_size is 2") {
+                    REQUIRE(fault_block_layer_get_size(layer.get()) == 2);
+                }
+
+                THEN("iget_block(0) returns block id 2") {
+                    fault_block_type *b =
+                        fault_block_layer_iget_block(layer.get(), 0);
+                    REQUIRE(fault_block_get_id(b) == 2);
+                }
+
+                THEN("iget_block(1) returns block id 3") {
+                    fault_block_type *b =
+                        fault_block_layer_iget_block(layer.get(), 1);
+                    REQUIRE(fault_block_get_id(b) == 3);
+                }
+
+                THEN("blocks 2 and 3 are still accessible by id") {
+                    REQUIRE(fault_block_layer_get_block(layer.get(), 2) !=
+                            nullptr);
+                    REQUIRE(fault_block_layer_get_block(layer.get(), 3) !=
+                            nullptr);
+                }
+            }
+
+            WHEN("The middle block (id=2) is deleted") {
+                fault_block_layer_del_block(layer.get(), 2);
+
+                THEN("get_size is 2") {
+                    REQUIRE(fault_block_layer_get_size(layer.get()) == 2);
+                }
+
+                THEN("blocks 1 and 3 are still accessible by id") {
+                    REQUIRE(fault_block_layer_get_block(layer.get(), 1) !=
+                            nullptr);
+                    REQUIRE(fault_block_layer_get_block(layer.get(), 3) !=
+                            nullptr);
+                }
+
+                THEN("block 2 is no longer accessible") {
+                    REQUIRE(fault_block_layer_get_block(layer.get(), 2) ==
+                            nullptr);
+                }
+            }
+
+            WHEN("The last block (id=3) is deleted") {
+                fault_block_layer_del_block(layer.get(), 3);
+
+                THEN("get_size is 2") {
+                    REQUIRE(fault_block_layer_get_size(layer.get()) == 2);
+                }
+
+                THEN("blocks 1 and 2 are still accessible by id") {
+                    REQUIRE(fault_block_layer_get_block(layer.get(), 1) !=
+                            nullptr);
+                    REQUIRE(fault_block_layer_get_block(layer.get(), 2) !=
+                            nullptr);
+                }
+            }
+            WHEN("All blocks are deleted") {
+                fault_block_layer_del_block(layer.get(), 1);
+                fault_block_layer_del_block(layer.get(), 2);
+                fault_block_layer_del_block(layer.get(), 3);
+
+                THEN("get_size returns 0") {
+                    REQUIRE(fault_block_layer_get_size(layer.get()) == 0);
+                }
+            }
+        }
+        GIVEN("A block with id=5") {
+            fault_block_layer_add_block(layer.get(), 5);
+
+            WHEN("Block 5 is deleted and then re-added") {
+                fault_block_layer_del_block(layer.get(), 5);
+                fault_block_type *new_block =
+                    fault_block_layer_add_block(layer.get(), 5);
+
+                THEN("The new add succeeds") { REQUIRE(new_block != nullptr); }
+
+                THEN("get_size is 1") {
+                    REQUIRE(fault_block_layer_get_size(layer.get()) == 1);
+                }
+
+                THEN("has_block returns true for id 5") {
+                    REQUIRE(fault_block_layer_has_block(layer.get(), 5));
+                }
+            }
+            WHEN("Block 5 is deleted") {
+                fault_block_layer_del_block(layer.get(), 5);
+
+                // block_map is not shrunk on deletion, so get_next_id remains
+                // at max+1 rather than reverting to the pre-add value.
+                THEN("get_next_id is still 6 (block_map is not shrunk)") {
+                    REQUIRE(fault_block_layer_get_next_id(layer.get()) == 6);
+                }
+
+                THEN("get_size is 0") {
+                    REQUIRE(fault_block_layer_get_size(layer.get()) == 0);
+                }
+            }
+        }
+        AND_GIVEN("A kw with nonzero data in k=2") {
+            auto kw = make_kw("FAULTBLK", nx * ny * nz, RD_INT);
+
+            // Two cells with block id=1 in the last layer only
+            rd_kw_iset_int(kw.get(),
+                           rd_grid_get_global_index3(grid.get(), 0, 0, 2), 1);
+            rd_kw_iset_int(kw.get(),
+                           rd_grid_get_global_index3(grid.get(), 1, 0, 2), 1);
+
+            WHEN("scan_kw is called on layer k=2 (last layer, where data "
+                 "lives)") {
+                auto layer_2 = make_fb_layer(grid.get(), 2);
+                bool ok = fault_block_layer_scan_kw(layer_2.get(), kw.get());
+
+                THEN("scan_kw returns true") { REQUIRE(ok); }
+
+                // The two non-zero cells form one block; the remaining 7 zero
+                // cells are grouped into a second block.
+                THEN("Two blocks are created") {
+                    REQUIRE(fault_block_layer_get_size(layer_2.get()) == 2);
+                }
+            }
+
+            WHEN("scan_kw is called on layer k=0 (no data in this layer)") {
+                fault_block_layer_scan_kw(layer.get(), kw.get());
+
+                // All cells in k=0 are zero; assign_zero groups them into one
+                // single connected block.
+                THEN("Only one block is created (all cells are zero)") {
+                    REQUIRE(fault_block_layer_get_size(layer.get()) == 1);
+                }
+            }
+        }
+    }
+}

--- a/lib/tests/test_layer.cpp
+++ b/lib/tests/test_layer.cpp
@@ -86,8 +86,7 @@ TEST_CASE("Layer getters and setters", "[layer]") {
     GIVEN("A layer") {
         int nx = 10;
         int ny = 8;
-        std::unique_ptr<layer_type, decltype(&layer_free)> layer(
-            layer_alloc(nx, ny), layer_free);
+        auto layer = make_layer(nx, ny);
 
         WHEN("Getting dimensions") {
             int result_nx = layer_get_nx(layer.get());
@@ -270,8 +269,7 @@ TEST_CASE("Layer getters and setters", "[layer]") {
             }
         }
         AND_GIVEN("A layer of the same size") {
-            std::unique_ptr<layer_type, decltype(&layer_free)> dst(
-                layer_alloc(nx, ny), layer_free);
+            auto dst = make_layer(nx, ny);
 
             WHEN("Source layer has some values set") {
                 layer_iset_cell_value(layer.get(), 1, 1, 10);

--- a/lib/tests/test_layer.cpp
+++ b/lib/tests/test_layer.cpp
@@ -25,12 +25,6 @@ inline std::ostream &operator<<(std::ostream &os,
     return os;
 }
 
-static std::unique_ptr<int_vector_type, decltype(&int_vector_free)>
-make_int_vector() {
-    return std::unique_ptr<int_vector_type, decltype(&int_vector_free)>(
-        int_vector_alloc(0, 0), int_vector_free);
-}
-
 static std::unique_ptr<rd_grid_type, decltype(&rd_grid_free)>
 generate_coordkw_grid(
     int num_x, int num_y, int num_z,
@@ -295,8 +289,8 @@ TEST_CASE("Layer getters and setters", "[layer]") {
             layer_iset_cell_value(layer.get(), 3, 3, 7);
 
             AND_WHEN("Finding cells equal to value 7") {
-                auto i_list = make_int_vector();
-                auto j_list = make_int_vector();
+                auto i_list = make_int_vector(0, 0);
+                auto j_list = make_int_vector(0, 0);
                 layer_cells_equal(layer.get(), 7, i_list.get(), j_list.get());
 
                 THEN("Three cells are found") {
@@ -321,8 +315,8 @@ TEST_CASE("Layer getters and setters", "[layer]") {
             }
 
             AND_WHEN("Tracing block content") {
-                auto i_list = make_int_vector();
-                auto j_list = make_int_vector();
+                auto i_list = make_int_vector(0, 0);
+                auto j_list = make_int_vector(0, 0);
 
                 AND_WHEN("Tracing block content without erasing") {
                     bool traced =
@@ -374,7 +368,7 @@ TEST_CASE("Layer getters and setters", "[layer]") {
 
             AND_WHEN("Tracing edges") {
                 std::vector<int_point2d_type> corner_list;
-                auto cell_list = make_int_vector();
+                auto cell_list = make_int_vector(0, 0);
                 THEN("The 3x3 block is traced when value is 42") {
                     REQUIRE(layer_trace_block_edge(
                         layer.get(), 2, 2, 42, corner_list, cell_list.get()));
@@ -431,7 +425,7 @@ TEST_CASE("Layer getters and setters", "[layer]") {
 
         WHEN("Tracing edges") {
             std::vector<int_point2d_type> corner_list;
-            auto cell_list = make_int_vector();
+            auto cell_list = make_int_vector(0, 0);
 
             GIVEN("A single non-zero cell block") {
                 layer_iset_cell_value(layer.get(), 5, 5, 7);

--- a/lib/util/vector_template.cpp.in
+++ b/lib/util/vector_template.cpp.in
@@ -99,6 +99,7 @@
 #include <cmath>
 #include <functional>
 #include <numeric>
+#include <memory>
 
 #include <ert/util/type_macros.hpp>
 #include <ert/util/util.hpp>
@@ -1520,3 +1521,7 @@ void @TYPE@_vector_range_fill(@TYPE@_vector_type * vector , @TYPE@ limit1 , @TYP
 #ifdef __cplusplus
 }
 #endif
+std::unique_ptr<@TYPE@_vector_type, decltype(&@TYPE@_vector_free)>
+make_@TYPE@_vector(int init_size , @TYPE@ default_value) {
+    return {@TYPE@_vector_alloc(init_size, default_value), @TYPE@_vector_free};
+}

--- a/lib/vector_template.hpp.in
+++ b/lib/vector_template.hpp.in
@@ -18,6 +18,7 @@
 
 #ifndef ERT_@TYPE@_VECTOR_H
 #define ERT_@TYPE@_VECTOR_H
+#include <memory>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -126,6 +127,7 @@ typedef @TYPE@ (@TYPE@_ftype) (@TYPE@);
 #ifdef __cplusplus
 }
 #endif
+std::unique_ptr<@TYPE@_vector_type, decltype(&@TYPE@_vector_free)> make_@TYPE@_vector(int, @TYPE@);
 #endif
 //
 


### PR DESCRIPTION
Note that in particular this changes `util_abort` to `.at()` out-of-range exceptions in some cases.