### PR TITLE
Handle missing MAPAXES export when mapaxes is absent

### DIFF
--- a/lib/resdata/rd_grid.cpp
+++ b/lib/resdata/rd_grid.cpp
@@ -4706,7 +4706,10 @@ static const float *rd_grid_get_mapaxes(const rd_grid_type *grid) {
 }
 
 rd_kw_type *rd_grid_alloc_mapaxes_kw(const rd_grid_type *grid) {
-    return rd_kw_alloc_new(MAPAXES_KW, 6, RD_FLOAT, grid->mapaxes);
+    const float *mapaxes = rd_grid_get_mapaxes(grid);
+    const int mapaxes_size = mapaxes != NULL ? 6 : 0;
+
+    return rd_kw_alloc_new(MAPAXES_KW, mapaxes_size, RD_FLOAT, mapaxes);
 }
 
 static rd_kw_type *rd_grid_alloc_mapunits_kw(ert_rd_unit_enum output_unit) {

--- a/lib/resdata/tests/rd_grid_export.cpp
+++ b/lib/resdata/tests/rd_grid_export.cpp
@@ -78,7 +78,20 @@ void export_mapaxes(const rd_grid_type *grid, rd_file_type *rd_file) {
     }
 }
 
+void export_empty_mapaxes_kw() {
+    rd_grid_type *grid = rd_grid_alloc_rectangular(4, 4, 2, 1, 1, 1, NULL);
+    rd_kw_type *mapaxes_kw = rd_grid_alloc_mapaxes_kw(grid);
+
+    test_assert_not_NULL(mapaxes_kw);
+    test_assert_int_equal(rd_kw_get_size(mapaxes_kw), 0);
+    test_assert_NULL(rd_kw_get_float_ptr(mapaxes_kw));
+
+    rd_kw_free(mapaxes_kw);
+    rd_grid_free(grid);
+}
+
 int main(int argc, char **argv) {
+    export_empty_mapaxes_kw();
     rd::util::TestArea ta("grid_export");
     {
         const char *test_grid = "TEST.EGRID";


### PR DESCRIPTION
Make `rd_grid_alloc_mapaxes_kw()` handle grids without mapaxes.

I added a regression test for the case where `rd_grid_alloc_mapaxes_kw()` is called for a grid with no `MAPAXES` data, which was the issue in #1117.

Then I changed the implementation so it returns an empty keyword instead of a size-6 keyword with null backing data.
