### PR TITLE
Fix util_abort called with too few arguments

### DIFF
--- a/lib/resdata/rd_grid.cpp
+++ b/lib/resdata/rd_grid.cpp
@@ -5258,7 +5258,7 @@ void rd_grid_compressed_kw_copy(const rd_grid_type *grid, rd_kw_type *target_kw,
         }
     } else
         util_abort("%s: size mismatch target:%d  src:%d  expected %d,%d \n",
-                   rd_kw_get_size(target_kw), rd_kw_get_size(src_kw),
+                   __func__, rd_kw_get_size(target_kw), rd_kw_get_size(src_kw),
                    rd_grid_get_nactive(grid), rd_grid_get_global_size(grid));
 }
 
@@ -5275,7 +5275,7 @@ void rd_grid_global_kw_copy(const rd_grid_type *grid, rd_kw_type *target_kw,
         }
     } else
         util_abort("%s: size mismatch target:%d  src:%d  expected %d,%d \n",
-                   rd_kw_get_size(target_kw), rd_kw_get_size(src_kw),
+                   __func__, rd_kw_get_size(target_kw), rd_kw_get_size(src_kw),
                    rd_grid_get_global_size(grid), rd_grid_get_nactive(grid));
 }
 

--- a/lib/resdata/well_segment.cpp
+++ b/lib/resdata/well_segment.cpp
@@ -164,7 +164,7 @@ void well_segment_link_strict(well_segment_type *segment,
     if (!well_segment_link(segment, outlet_segment))
         util_abort(
             "%s: tried to create invalid link between segments %d and %d \n",
-            segment->segment_id, outlet_segment->segment_id);
+            __func__, segment->segment_id, outlet_segment->segment_id);
 }
 
 bool well_segment_has_grid_connections(const well_segment_type *segment,


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/resdata/security/code-scanning/9 and two similar security reports
