### PR TITLE
Make ResdataKW.read_grdecl use pybind

### DIFF
--- a/applications/resdata/grdecl_test.cpp
+++ b/applications/resdata/grdecl_test.cpp
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
         while (true) {
             rd_kw_type *grdecl_kw;
             clock_t begin = clock();
-            grdecl_kw = rd_kw_fscanf_alloc_grdecl(stream, NULL, 0, RD_FLOAT);
+            grdecl_kw = rd_kw_fscanf_alloc_grdecl(stream, nullptr, RD_FLOAT);
             clock_t end = clock();
             double time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
 

--- a/applications/resdata/grdecl_test.cpp
+++ b/applications/resdata/grdecl_test.cpp
@@ -21,6 +21,7 @@
 
 #include <ert/util/util.hpp>
 #include <resdata/rd_kw.hpp>
+#include <resdata/rd_kw_grdecl.hpp>
 
 int main(int argc, char **argv) {
     fprintf(stderr,

--- a/applications/resdata/grdecl_test.cpp
+++ b/applications/resdata/grdecl_test.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
         while (true) {
             rd_kw_type *grdecl_kw;
             clock_t begin = clock();
-            grdecl_kw = rd_kw_fscanf_alloc_current_grdecl(stream, RD_FLOAT);
+            grdecl_kw = rd_kw_fscanf_alloc_grdecl(stream, NULL, 0, RD_FLOAT);
             clock_t end = clock();
             double time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -187,6 +187,32 @@ set_target_properties(
   _grid PROPERTIES LIBRARY_OUTPUT_DIRECTORY
                    ${PROJECT_SOURCE_DIR}/python/resdata/grid)
 
+# -----------------------------------------------------------------
+# Pybind11 extension module: resdata.resfile._kw
+# -----------------------------------------------------------------
+pybind11_add_module(_kw resdata/rd_kw_pybind.cpp)
+target_link_libraries(_kw PRIVATE resdata fmt::fmt)
+target_include_directories(_kw PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+                                       ${CMAKE_CURRENT_BINARY_DIR}/include)
+if(SKBUILD)
+  set(_kw_install_dir "python/resdata/resfile")
+  # libresdata.so.6 is installed at python/resdata/.libs/ make _kw.so find it
+  if(APPLE)
+    set_target_properties(_kw PROPERTIES INSTALL_RPATH "@loader_path/../.libs")
+  else()
+    set_target_properties(_kw PROPERTIES INSTALL_RPATH "$ORIGIN/../.libs")
+  endif()
+else()
+  set(_kw_install_dir "${CMAKE_INSTALL_LIBDIR}")
+endif()
+install(TARGETS _kw LIBRARY DESTINATION ${_kw_install_dir})
+# When running tests against the build tree (editable install), put the
+# extension directly next to rd_kw.py so it can be imported as
+# resdata.resfile._kw without an install step.
+set_target_properties(
+  _kw PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+                 ${PROJECT_SOURCE_DIR}/python/resdata/resfile)
+
 if(NOT BUILD_TESTS)
   return()
 endif()

--- a/lib/include/resdata/rd_kw.hpp
+++ b/lib/include/resdata/rd_kw.hpp
@@ -239,8 +239,6 @@ void rd_kw_fix_uninitialized(rd_kw_type *rd_kw, int nx, int ny, int nz,
 
 rd_type_enum rd_kw_get_type(const rd_kw_type *);
 
-#include <resdata/rd_kw_grdecl.hpp>
-
 #ifdef __cplusplus
 }
 #endif

--- a/lib/include/resdata/rd_kw_grdecl.hpp
+++ b/lib/include/resdata/rd_kw_grdecl.hpp
@@ -8,11 +8,9 @@
 
 bool rd_kw_grdecl_fseek_kw(const char *, bool, FILE *);
 
-rd_kw_type *rd_kw_fscanf_alloc_grdecl_dynamic(FILE *stream, const char *kw,
-                                              bool strict, rd_data_type);
-
-rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw, int size,
-                                      rd_data_type data_type);
+rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw,
+                                      rd_data_type data_type, int size = 0,
+                                      bool strict = true);
 
 void rd_kw_fprintf_grdecl(const rd_kw_type *rd_kw, FILE *stream,
                           const char *special_header = nullptr);

--- a/lib/include/resdata/rd_kw_grdecl.hpp
+++ b/lib/include/resdata/rd_kw_grdecl.hpp
@@ -18,9 +18,6 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl_dynamic(FILE *stream, const char *kw,
 rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw, int size,
                                       rd_data_type data_type);
 
-rd_kw_type *rd_kw_fscanf_alloc_current_grdecl(FILE *stream,
-                                              rd_data_type data_type);
-
 void rd_kw_fprintf_grdecl(const rd_kw_type *rd_kw, FILE *stream);
 void rd_kw_fprintf_grdecl__(const rd_kw_type *rd_kw, const char *special_header,
                             FILE *stream);

--- a/lib/include/resdata/rd_kw_grdecl.hpp
+++ b/lib/include/resdata/rd_kw_grdecl.hpp
@@ -1,14 +1,8 @@
-/*
- This header does not define datatypes; just a couple of functions. It should
- be included from the rd_kw.h header, so applications do not need to include this
- header explicitly.
-*/
+#pragma once
 
-#ifndef ERT_RD_KW_GRDECL_H
-#define ERT_RD_KW_GRDECL_H
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <cstdio>
+
+#include <resdata/rd_kw.hpp>
 
 bool rd_kw_grdecl_fseek_kw(const char *, bool, FILE *);
 
@@ -21,8 +15,3 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw, int size,
 void rd_kw_fprintf_grdecl(const rd_kw_type *rd_kw, FILE *stream);
 void rd_kw_fprintf_grdecl__(const rd_kw_type *rd_kw, const char *special_header,
                             FILE *stream);
-
-#ifdef __cplusplus
-}
-#endif
-#endif

--- a/lib/include/resdata/rd_kw_grdecl.hpp
+++ b/lib/include/resdata/rd_kw_grdecl.hpp
@@ -12,10 +12,8 @@ extern "C" {
 
 bool rd_kw_grdecl_fseek_kw(const char *, bool, FILE *);
 
-rd_kw_type *rd_kw_fscanf_alloc_grdecl_dynamic__(FILE *stream, const char *kw,
-                                                bool strict, rd_data_type);
 rd_kw_type *rd_kw_fscanf_alloc_grdecl_dynamic(FILE *stream, const char *kw,
-                                              rd_data_type);
+                                              bool strict, rd_data_type);
 
 rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw, int size,
                                       rd_data_type data_type);

--- a/lib/include/resdata/rd_kw_grdecl.hpp
+++ b/lib/include/resdata/rd_kw_grdecl.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cstdio>
+#include <optional>
+#include <string>
 
 #include <resdata/rd_kw.hpp>
 
@@ -12,6 +14,5 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl_dynamic(FILE *stream, const char *kw,
 rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw, int size,
                                       rd_data_type data_type);
 
-void rd_kw_fprintf_grdecl(const rd_kw_type *rd_kw, FILE *stream);
-void rd_kw_fprintf_grdecl__(const rd_kw_type *rd_kw, const char *special_header,
-                            FILE *stream);
+void rd_kw_fprintf_grdecl(const rd_kw_type *rd_kw, FILE *stream,
+                          const char *special_header = nullptr);

--- a/lib/include/resdata/rd_type.hpp
+++ b/lib/include/resdata/rd_type.hpp
@@ -4,6 +4,9 @@
 #include <cstdlib>
 
 #ifdef __cplusplus
+
+#include <string>
+
 extern "C" {
 #endif
 
@@ -118,6 +121,8 @@ bool rd_type_is_string(const rd_data_type);
 
 #ifdef __cplusplus
 }
+
+std::string rd_type_name(const rd_data_type);
 #endif
 
 #endif

--- a/lib/resdata/rd_grid.cpp
+++ b/lib/resdata/rd_grid.cpp
@@ -4491,9 +4491,9 @@ void rd_grid_grdecl_fprintf_kw(const rd_grid_type *rd_grid,
                                const char *special_header, FILE *stream,
                                double double_default) {
     int src_size = rd_kw_get_size(rd_kw);
-    if (src_size == rd_grid->size)
-        rd_kw_fprintf_grdecl__(rd_kw, special_header, stream);
-    else if (src_size == rd_grid->total_active) {
+    if (src_size == rd_grid->size) {
+        rd_kw_fprintf_grdecl(rd_kw, stream, special_header);
+    } else if (src_size == rd_grid->total_active) {
         void *default_ptr = NULL;
         float float_default;
         int int_default;
@@ -4534,7 +4534,7 @@ void rd_grid_grdecl_fprintf_kw(const rd_grid_type *rd_grid,
                               rd_kw, rd_grid->size,
                               rd_grid->inv_index_map.data(), default_ptr),
                           &rd_kw_free);
-            rd_kw_fprintf_grdecl__(tmp_kw.get(), special_header, stream);
+            rd_kw_fprintf_grdecl(tmp_kw.get(), stream, special_header);
         }
     } else
         throw std::invalid_argument(fmt::format(

--- a/lib/resdata/rd_grid.cpp
+++ b/lib/resdata/rd_grid.cpp
@@ -29,6 +29,7 @@
 #include <resdata/rd_util.hpp>
 #include <resdata/rd_type.hpp>
 #include <resdata/rd_kw.hpp>
+#include <resdata/rd_kw_grdecl.hpp>
 #include <resdata/rd_file.hpp>
 #include <resdata/rd_kw_magic.hpp>
 #include <resdata/rd_endian_flip.hpp>

--- a/lib/resdata/rd_kw.cpp
+++ b/lib/resdata/rd_kw.cpp
@@ -2360,6 +2360,9 @@ void rd_kw_max_min(const rd_kw_type *rd_kw, void *_max, void *_min) {
 #define RD_KW_MAX_MIN(ctype)                                                   \
     void rd_kw_max_min_##ctype(const rd_kw_type *rd_kw, ctype *_max,           \
                                ctype *_min) {                                  \
+        if (rd_kw->size < 1)                                                   \
+            util_abort("%s: size of zero length array is undefined \n",        \
+                       __func__);                                              \
         KW_MAX_MIN(ctype);                                                     \
     }
 

--- a/lib/resdata/rd_kw_grdecl.cpp
+++ b/lib/resdata/rd_kw_grdecl.cpp
@@ -452,16 +452,10 @@ static rd_kw_type *__rd_kw_fscanf_alloc_grdecl__(FILE *stream,
    the whole keyword is loaded, and then return.
 */
 
-rd_kw_type *rd_kw_fscanf_alloc_grdecl_dynamic__(FILE *stream, const char *kw,
-                                                bool strict,
-                                                rd_data_type data_type) {
-    return __rd_kw_fscanf_alloc_grdecl__(stream, kw, strict, 0, data_type);
-}
-
 rd_kw_type *rd_kw_fscanf_alloc_grdecl_dynamic(FILE *stream, const char *kw,
+                                              bool strict,
                                               rd_data_type data_type) {
-    bool strict = true;
-    return rd_kw_fscanf_alloc_grdecl_dynamic__(stream, kw, strict, data_type);
+    return __rd_kw_fscanf_alloc_grdecl__(stream, kw, strict, 0, data_type);
 }
 
 /*

--- a/lib/resdata/rd_kw_grdecl.cpp
+++ b/lib/resdata/rd_kw_grdecl.cpp
@@ -231,9 +231,9 @@ void checked_realloc(std::unique_ptr<T[], void (*)(void *)> &ptr,
 
    Observe that no-spaces-are-allowed-around-the-*
 */
-static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
-                                      rd_data_type data_type, int *kw_size,
-                                      FILE *stream) {
+static std::unique_ptr<char[], void (*)(void *)>
+fscanf_alloc_grdecl_data(const char *header, bool strict,
+                         rd_data_type data_type, int *kw_size, FILE *stream) {
     char newline = '\n';
     bool atEOF = false;
     size_t init_size = 32;
@@ -355,7 +355,7 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
     }
     *kw_size = data_index;
     checked_realloc<char>(data, sizeof_ctype * data_index * sizeof *data.get());
-    return data.release();
+    return data;
 }
 
 /*
@@ -420,13 +420,12 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw,
         char file_header[MAX_GRDECL_HEADER_SIZE] = {0};
         if (fscanf(stream, MAX_GRDECL_HEADER_SCANF_FMT, file_header) == 1) {
             int kw_size;
-            char *data = fscanf_alloc_grdecl_data(file_header, strict,
-                                                  data_type, &kw_size, stream);
+            auto data = fscanf_alloc_grdecl_data(file_header, strict, data_type,
+                                                 &kw_size, stream);
 
             // Verify size
             if (size > 0)
                 if (size != kw_size) {
-                    free(data);
                     throw std::invalid_argument(
                         fmt::format("size mismatch when loading:{}. File:{} "
                                     "elements. Requested:{} elements",
@@ -436,7 +435,7 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw,
             {
                 rd_kw_type *rd_kw =
                     rd_kw_alloc_new(file_header, kw_size, data_type, NULL);
-                rd_kw_set_data_ptr(rd_kw, data);
+                rd_kw_set_data_ptr(rd_kw, data.release());
                 return rd_kw;
             }
 

--- a/lib/resdata/rd_kw_grdecl.cpp
+++ b/lib/resdata/rd_kw_grdecl.cpp
@@ -175,6 +175,33 @@ static void iset_range(char *data, int data_index, int sizeof_ctype,
     }
 }
 
+template <typename T>
+std::unique_ptr<T[], void (*)(void *)> checked_calloc(size_t num) {
+    T *ptr = static_cast<T *>(std::calloc(num, sizeof(T)));
+
+    if (ptr == nullptr) {
+        throw std::bad_alloc{};
+    }
+    return std::unique_ptr<T[], void (*)(void *)>(
+        ptr, [](void *p) { std::free(p); });
+}
+
+template <typename T>
+void checked_realloc(std::unique_ptr<T[], void (*)(void *)> &ptr,
+                     size_t new_element_count) {
+    if (new_element_count == 0) {
+        ptr.reset();
+        return;
+    }
+    T *raw_ptr = ptr.release();
+    void *new_raw_ptr = std::realloc(raw_ptr, new_element_count * sizeof(T));
+    if (new_raw_ptr == nullptr) {
+        ptr.reset(raw_ptr);
+        throw std::bad_alloc{};
+    }
+    ptr.reset(static_cast<T *>(new_raw_ptr));
+}
+
 /**
    The @strict flag is used to indicate whether the loader will accept
    character strings embedded into a numerical grdecl keyword; this
@@ -213,12 +240,12 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
     size_t data_index = 0;
     int sizeof_ctype = rd_type_get_sizeof_ctype(data_type);
     size_t data_size = init_size;
-    char *buffer = (char *)util_calloc((buffer_size + 1), sizeof *buffer);
-    char *data = (char *)util_calloc(sizeof_ctype * data_size, sizeof *data);
+    auto buffer = checked_calloc<char>(buffer_size + 1);
+    auto data = checked_calloc<char>(sizeof_ctype * data_size);
 
     while (true) {
-        if (fscanf(stream, "%32s", buffer) == 1) {
-            if (strcmp(buffer, RD_COMMENT_STRING) == 0) {
+        if (fscanf(stream, "%32s", buffer.get()) == 1) {
+            if (strcmp(buffer.get(), RD_COMMENT_STRING) == 0) {
                 // We have read a comment marker - just read up to the end of line.
                 char c;
                 while (true) {
@@ -230,7 +257,7 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
                         break;
                     }
                 }
-            } else if (strcmp(buffer, RD_DATA_TERMINATION) == 0)
+            } else if (strcmp(buffer.get(), RD_DATA_TERMINATION) == 0)
                 break;
             else {
                 // We have read a valid input string; scan numerical input values from it.
@@ -246,39 +273,40 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
                 bool char_input = false;
 
                 if (rd_type_is_int(data_type)) {
-                    if (sscanf(buffer, "%d*%d", &multiplier, &value.i) == 2) {
-                    } else if (sscanf(buffer, "%d", &value.i) == 1)
+                    if (sscanf(buffer.get(), "%d*%d", &multiplier, &value.i) ==
+                        2) {
+                    } else if (sscanf(buffer.get(), "%d", &value.i) == 1)
                         multiplier = 1;
                     else {
                         char_input = true;
                         if (strict)
                             util_abort("%s: Malformed content:\"%s\" when "
                                        "reading keyword:%s \n",
-                                       __func__, buffer, header);
+                                       __func__, buffer.get(), header);
                     }
                 } else if (rd_type_is_float(data_type)) {
-                    if (sscanf(buffer, "%d*%128g", &multiplier, &value.f) ==
-                        2) {
-                    } else if (sscanf(buffer, "%128g", &value.f) == 1)
+                    if (sscanf(buffer.get(), "%d*%128g", &multiplier,
+                               &value.f) == 2) {
+                    } else if (sscanf(buffer.get(), "%128g", &value.f) == 1)
                         multiplier = 1;
                     else {
                         char_input = true;
                         if (strict)
                             util_abort("%s: Malformed content:\"%s\" when "
                                        "reading keyword:%s \n",
-                                       __func__, buffer, header);
+                                       __func__, buffer.get(), header);
                     }
                 } else if (rd_type_is_double(data_type)) {
-                    if (sscanf(buffer, "%d*%128lg", &multiplier, &value.d) ==
-                        2) {
-                    } else if (sscanf(buffer, "%128lg", &value.d) == 1)
+                    if (sscanf(buffer.get(), "%d*%128lg", &multiplier,
+                               &value.d) == 2) {
+                    } else if (sscanf(buffer.get(), "%128lg", &value.d) == 1)
                         multiplier = 1;
                     else {
                         char_input = true;
                         if (strict)
                             util_abort("%s: Malformed content:\"%s\" when "
                                        "reading keyword:%s \n",
-                                       __func__, buffer, header);
+                                       __func__, buffer.get(), header);
                     }
                 } else
                     util_abort("%s: sorry type:%s not supported \n", __func__,
@@ -291,13 +319,14 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
                     size_t min_size = data_index + multiplier;
                     if (min_size >= data_size) {
                         if (min_size <= RD_KW_MAX_SIZE) {
-                            size_t byte_size = sizeof_ctype * sizeof *data;
+                            size_t byte_size =
+                                sizeof_ctype * sizeof *data.get();
 
                             data_size = util_size_t_min(
                                 RD_KW_MAX_SIZE, 2 * (data_index + multiplier));
                             byte_size *= data_size;
 
-                            data = (char *)util_realloc(data, byte_size);
+                            checked_realloc<char>(data, byte_size);
                         } else {
                             // We are asking for more elements than can possible
                             // be adressed in an integer. Return NULL - and
@@ -307,7 +336,7 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
                         }
                     }
 
-                    iset_range(data, data_index, sizeof_ctype, &value,
+                    iset_range(data.get(), data_index, sizeof_ctype, &value,
                                multiplier);
                     data_index += multiplier;
                 }
@@ -317,10 +346,9 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
         } else
             break;
     }
-    free(buffer);
     *kw_size = data_index;
-    data = (char *)util_realloc(data, sizeof_ctype * data_index * sizeof *data);
-    return data;
+    checked_realloc<char>(data, sizeof_ctype * data_index * sizeof *data.get());
+    return data.release();
 }
 
 /*

--- a/lib/resdata/rd_kw_grdecl.cpp
+++ b/lib/resdata/rd_kw_grdecl.cpp
@@ -344,74 +344,56 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
    current position, otherwise it will start with seeking to find @kw
    first.
 
-   Observe that the grdecl files are very weakly structured, so the
-   loading of rd_kw instances from a grdecl file can go wrong in many
-   ways; if the loading fails the function returns NULL.
-
-   The main loop is extremely simple - it is just repeated calls to
-   fscanf() to read one-number-at-atime; when that reading fails that
-   is interpreted as the end of the keyword.
-
-   Currently ONLY integer and float types are supported in rd_type -
+   Currently only integer and float types are supported in rd_type -
    any other types will lead to a hard failure.
 
    The rd_kw class has a quite deeply wired assumption that the
-   header is a string of length 8 (I hope/think that is an ECLIPSE
+   header is a string of length 8 (that is an ECLIPSE
    limitation). The class cannot read/write kw with headers longer than 8 bytes.
    rd_kw_grdecl is a workaround allowing for reading/writing kw with long
    headers.
 
-   -----------------------------------------------------------------
+   kw: If the @kw argument is != NULL the function will start
+     by seeking through the file to find the kw string; if the
+     kw can not be found the function will return NULL - but not
+     fail any more than that.
 
-    header: If the @header argument is != NULL the function will start
-      by seeking through the file to find the header string; if the
-      header can not be found the function will return NULL - but not
-      fail any more than that.
+     If @kw == NULL on input the function will just fscanf() the
+     first available string and use that as kw for the
+     keyword. This can lead to failure in a zillion different ways;
+     it is highly recommended to supply a valid string for the
+     @kw argument.
 
-      If @kw == NULL on input the function will just fscanf() the
-      first available string and use that as header for the
-      keyword. This can lead to failure in a zillion different ways;
-      it is highly recommended to supply a valid string for the
-      @header argument.
-
-    strict: see the documentation of the strict flag in the
-      fscanf_alloc_grdecl_data() function. Most of the exported
-      functions have hardwired strict = true.
+   strict: see the documentation of the strict flag in the
+     fscanf_alloc_grdecl_data() function. Most of the exported
+     functions have hardwired strict = true.
 
 
-    size: If the @size is set to <= 0 the function will just load all
-      data it can find until a terminating '/' is found. If a size
-      argument is given the function will check that there is
-      agreement between the size input argument and the number of
-      elements found on the file.
+   size: If the @size is set to <= 0 the function will just load all
+     data it can find until a terminating '/' is found. If a size
+     argument is given the function will check that there is
+     agreement between the size input argument and the number of
+     elements found on the file.
 
 
-    rd_type: The files have no embedded type information and the type
-      must be supplied by the calling scope. Currently only the
-      RD_FLOAT_TYPE and RD_INT_TYPE types are supported.
-
-   -----------------------------------------------------------------
-
-   This function is static; there are several exported varieties with
-   different sets of default values. These files are tricky to load -
-   if there is something wrong it can be difficult to detect.
+   rd_type: The files have no embedded type information and the type
+     must be supplied by the calling scope. Currently only the
+     RD_FLOAT_TYPE and RD_INT_TYPE types are supported.
 */
-
-static rd_kw_type *__rd_kw_fscanf_alloc_grdecl__(FILE *stream,
-                                                 const char *header,
-                                                 bool strict, int size,
-                                                 rd_data_type data_type) {
-    if (header && strlen(header) >= MAX_GRDECL_HEADER_SIZE)
+rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw,
+                                      rd_data_type data_type, int size = 0,
+                                      bool strict = true) {
+    if (kw && strlen(kw) >= MAX_GRDECL_HEADER_SIZE)
         util_abort(
-            "%s cannot read KW of more than %d bytes. strlen(header) == %d\n",
-            __func__, MAX_GRDECL_HEADER_SIZE, strlen(header));
+            "%s cannot read KW of more than %d bytes. strlen(kw) == %d\n",
+            __func__, MAX_GRDECL_HEADER_SIZE, strlen(kw));
 
     if (!rd_type_is_numeric(data_type))
         util_abort("%s: sorry only types FLOAT, INT and DOUBLE supported\n",
                    __func__);
 
-    if (header != NULL)
-        if (!rd_kw_grdecl_fseek_kw(header, true, stream))
+    if (kw != NULL)
+        if (!rd_kw_grdecl_fseek_kw(kw, true, stream))
             return NULL; /* Could not find it. */
 
     {
@@ -441,47 +423,6 @@ static rd_kw_type *__rd_kw_fscanf_alloc_grdecl__(FILE *stream,
             /** No header read - probably at EOF */
             return NULL;
     }
-}
-
-/*
-   This function will seek through the file and position the file
-   pointer at the beginning of @kw before starting to load (this
-   includes rewinding the file pointer). If @kw can not be found the
-   function will return NULL.
-
-   As size is not supplied the function will keep loading data until
-   the whole keyword is loaded, and then return.
-*/
-
-rd_kw_type *rd_kw_fscanf_alloc_grdecl_dynamic(FILE *stream, const char *kw,
-                                              bool strict,
-                                              rd_data_type data_type) {
-    return __rd_kw_fscanf_alloc_grdecl__(stream, kw, strict, 0, data_type);
-}
-
-/*
-   This function will seek through the file and position the file
-   pointer at the beginning of @kw before starting to load (this
-   includes rewinding the file pointer). If @kw can not be found the
-   function will return NULL.
-
-   When the data has been loaded the function will compare actual size
-   with the supplied size argument and verify equality; if they differ
-   it will crash hard. If you are uncertain of the size use the
-   rd_kw_fscanf_alloc_grdecl_dynamic() function instead; or supply
-   size == 0.
-*/
-
-static rd_kw_type *rd_kw_fscanf_alloc_grdecl__(FILE *stream, const char *kw,
-                                               bool strict, int size,
-                                               rd_data_type data_type) {
-    return __rd_kw_fscanf_alloc_grdecl__(stream, kw, strict, size, data_type);
-}
-
-rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw, int size,
-                                      rd_data_type data_type) {
-    bool strict = true;
-    return rd_kw_fscanf_alloc_grdecl__(stream, kw, strict, size, data_type);
 }
 
 /*

--- a/lib/resdata/rd_kw_grdecl.cpp
+++ b/lib/resdata/rd_kw_grdecl.cpp
@@ -232,8 +232,8 @@ void checked_realloc(std::unique_ptr<T[], void (*)(void *)> &ptr,
    Observe that no-spaces-are-allowed-around-the-*
 */
 static std::unique_ptr<char[], void (*)(void *)>
-fscanf_alloc_grdecl_data(const char *header, bool strict,
-                         rd_data_type data_type, int *kw_size, FILE *stream) {
+fscanf_grdecl_data(const char *header, bool strict, rd_data_type data_type,
+                   int *kw_size, FILE *stream) {
     char newline = '\n';
     bool atEOF = false;
     size_t init_size = 32;
@@ -385,7 +385,7 @@ fscanf_alloc_grdecl_data(const char *header, bool strict,
      @kw argument.
 
    strict: see the documentation of the strict flag in the
-     fscanf_alloc_grdecl_data() function. Most of the exported
+     fscanf_grdecl_data() function. Most of the exported
      functions have hardwired strict = true.
 
 
@@ -420,8 +420,8 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw,
         char file_header[MAX_GRDECL_HEADER_SIZE] = {0};
         if (fscanf(stream, MAX_GRDECL_HEADER_SCANF_FMT, file_header) == 1) {
             int kw_size;
-            auto data = fscanf_alloc_grdecl_data(file_header, strict, data_type,
-                                                 &kw_size, stream);
+            auto data = fscanf_grdecl_data(file_header, strict, data_type,
+                                           &kw_size, stream);
 
             // Verify size
             if (size > 0)

--- a/lib/resdata/rd_kw_grdecl.cpp
+++ b/lib/resdata/rd_kw_grdecl.cpp
@@ -161,21 +161,6 @@ bool rd_kw_grdecl_fseek_kw(const char *kw, bool rewind, FILE *stream) {
     return false;
 }
 
-/**
-   Observe that this function does not preserve the '*' structure
-   which (might) have been used in the input.
-*/
-static void iset_range(char *data, int data_index, int sizeof_ctype,
-                       void *value_ptr, int multiplier) {
-    size_t byte_offset;
-    for (int index = 0; index < multiplier; index++) {
-        byte_offset =
-            static_cast<size_t>(data_index) + static_cast<size_t>(index);
-        byte_offset *= sizeof_ctype;
-        memcpy(&data[byte_offset], value_ptr, sizeof_ctype);
-    }
-}
-
 template <typename T>
 std::unique_ptr<T[], void (*)(void *)> checked_calloc(size_t num) {
     T *ptr = static_cast<T *>(std::calloc(num, sizeof(T)));
@@ -201,6 +186,31 @@ void checked_realloc(std::unique_ptr<T[], void (*)(void *)> &ptr,
         throw std::bad_alloc{};
     }
     ptr.reset(static_cast<T *>(new_raw_ptr));
+}
+template <typename T> constexpr const char *value_format();
+template <> constexpr const char *value_format<int>() { return "%d"; }
+template <> constexpr const char *value_format<float>() { return "%128g"; }
+template <> constexpr const char *value_format<double>() { return "%128lg"; }
+
+template <typename T> constexpr const char *multiplier_format();
+template <> constexpr const char *multiplier_format<int>() { return "%d*%d"; }
+template <> constexpr const char *multiplier_format<float>() {
+    return "%d*%128g";
+}
+template <> constexpr const char *multiplier_format<double>() {
+    return "%d*%128lg";
+}
+
+template <typename T>
+std::optional<T> scan_data(std::unique_ptr<char[], void (*)(void *)> &buffer,
+                           int &multiplier) {
+    T value;
+    if (sscanf(buffer.get(), multiplier_format<T>(), &multiplier, &value) == 2)
+        return value;
+    multiplier = 1;
+    if (sscanf(buffer.get(), value_format<T>(), &value) == 1)
+        return value;
+    return std::nullopt;
 }
 
 /**
@@ -231,18 +241,18 @@ void checked_realloc(std::unique_ptr<T[], void (*)(void *)> &ptr,
 
    Observe that no-spaces-are-allowed-around-the-*
 */
-static std::unique_ptr<char[], void (*)(void *)>
-fscanf_grdecl_data(const char *header, bool strict, rd_data_type data_type,
-                   int *kw_size, FILE *stream) {
+template <typename T>
+static std::unique_ptr<T[], void (*)(void *)>
+fscanf_grdecl_data(const char *header, bool strict, int &kw_size,
+                   FILE *stream) {
     char newline = '\n';
     bool atEOF = false;
     size_t init_size = 32;
     size_t buffer_size = 256;
     size_t data_index = 0;
-    int sizeof_ctype = rd_type_get_sizeof_ctype(data_type);
     size_t data_size = init_size;
     auto buffer = checked_calloc<char>(buffer_size + 1);
-    auto data = checked_calloc<char>(sizeof_ctype * data_size);
+    auto data = checked_calloc<T>(data_size);
 
     while (true) {
         if (fscanf(stream, "%32s", buffer.get()) == 1) {
@@ -264,76 +274,23 @@ fscanf_grdecl_data(const char *header, bool strict, rd_data_type data_type,
                 // We have read a valid input string; scan numerical input values from it.
                 // The multiplier algorithm will fail hard if there are spaces on either side
                 // of the '*'.
-                union {
-                    int i;
-                    float f;
-                    double d;
-                } value;
-
-                int multiplier;
-                bool char_input = false;
-
-                if (rd_type_is_int(data_type)) {
-                    if (sscanf(buffer.get(), "%d*%d", &multiplier, &value.i) ==
-                        2) {
-                    } else if (sscanf(buffer.get(), "%d", &value.i) == 1)
-                        multiplier = 1;
-                    else {
-                        char_input = true;
-                        if (strict)
-                            throw std::invalid_argument(
-                                fmt::format("Malformed content:\"{}\" when "
-                                            "reading keyword:{}",
-                                            std::string(buffer.get()),
-                                            std::string(header)));
-                    }
-                } else if (rd_type_is_float(data_type)) {
-                    if (sscanf(buffer.get(), "%d*%128g", &multiplier,
-                               &value.f) == 2) {
-                    } else if (sscanf(buffer.get(), "%128g", &value.f) == 1)
-                        multiplier = 1;
-                    else {
-                        char_input = true;
-                        if (strict)
-                            throw std::invalid_argument(
-                                fmt::format("Malformed content:\"{}\" when "
-                                            "reading keyword:{}",
-                                            std::string(buffer.get()),
-                                            std::string(header)));
-                    }
-                } else if (rd_type_is_double(data_type)) {
-                    if (sscanf(buffer.get(), "%d*%128lg", &multiplier,
-                               &value.d) == 2) {
-                    } else if (sscanf(buffer.get(), "%128lg", &value.d) == 1)
-                        multiplier = 1;
-                    else {
-                        char_input = true;
-                        if (strict)
-                            throw std::invalid_argument(
-                                fmt::format("Malformed content:\"{}\" when "
-                                            "reading keyword:{}",
-                                            std::string(buffer.get()),
-                                            std::string(header)));
-                    }
-                } else
+                int multiplier = 1;
+                auto value = scan_data<T>(buffer, multiplier);
+                if (!value && strict)
                     throw std::invalid_argument(fmt::format(
-                        "Type:{} not supported", rd_type_name(data_type)));
+                        "Malformed content:\"{}\" when reading keyword:{}",
+                        std::string(buffer.get()), std::string(header)));
 
                 // Removing this warning on user request:
                 // if (char_input)
                 // fprintf(stderr,"Warning: character string: \'%s\' ignored when reading keyword:%s \n",buffer , header);
-                if (!char_input) {
+                if (value) {
                     size_t min_size = data_index + multiplier;
                     if (min_size >= data_size) {
                         if (min_size <= RD_KW_MAX_SIZE) {
-                            size_t byte_size =
-                                sizeof_ctype * sizeof *data.get();
-
                             data_size = util_size_t_min(
                                 RD_KW_MAX_SIZE, 2 * (data_index + multiplier));
-                            byte_size *= data_size;
-
-                            checked_realloc<char>(data, byte_size);
+                            checked_realloc<T>(data, data_size);
                         } else {
                             // We are asking for more elements than can possible
                             // be adressed in an integer. Return NULL - and
@@ -343,9 +300,10 @@ fscanf_grdecl_data(const char *header, bool strict, rd_data_type data_type,
                         }
                     }
 
-                    iset_range(data.get(), data_index, sizeof_ctype, &value,
-                               multiplier);
-                    data_index += multiplier;
+                    size_t end = data_index + multiplier;
+                    while (data_index < end) {
+                        data[data_index++] = *value;
+                    }
                 }
             }
             if (atEOF)
@@ -353,8 +311,8 @@ fscanf_grdecl_data(const char *header, bool strict, rd_data_type data_type,
         } else
             break;
     }
-    *kw_size = data_index;
-    checked_realloc<char>(data, sizeof_ctype * data_index * sizeof *data.get());
+    kw_size = data_index;
+    checked_realloc<T>(data, data_index);
     return data;
 }
 
@@ -420,8 +378,22 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw,
         char file_header[MAX_GRDECL_HEADER_SIZE] = {0};
         if (fscanf(stream, MAX_GRDECL_HEADER_SCANF_FMT, file_header) == 1) {
             int kw_size;
-            auto data = fscanf_grdecl_data(file_header, strict, data_type,
-                                           &kw_size, stream);
+            std::unique_ptr<char[], void (*)(void *)> data{nullptr, &std::free};
+            if (rd_type_is_int(data_type)) {
+                data.reset((char *)(fscanf_grdecl_data<int>(file_header, strict,
+                                                            kw_size, stream)
+                                        .release()));
+            } else if (rd_type_is_float(data_type)) {
+                data.reset((char *)(fscanf_grdecl_data<float>(
+                                        file_header, strict, kw_size, stream)
+                                        .release()));
+            } else if (rd_type_is_double(data_type)) {
+                data.reset((char *)(fscanf_grdecl_data<double>(
+                                        file_header, strict, kw_size, stream)
+                                        .release()));
+            } else
+                throw std::invalid_argument(fmt::format(
+                    "Type:{} not supported", rd_type_name(data_type)));
 
             // Verify size
             if (size > 0)

--- a/lib/resdata/rd_kw_grdecl.cpp
+++ b/lib/resdata/rd_kw_grdecl.cpp
@@ -1,5 +1,6 @@
 #include <cstring>
 #include <cctype>
+#include <optional>
 
 #include <ert/util/util.hpp>
 
@@ -489,8 +490,8 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw, int size,
   length limit; i.e. loading it back naively will fail.
 */
 
-void rd_kw_fprintf_grdecl__(const rd_kw_type *rd_kw, const char *special_header,
-                            FILE *stream) {
+void rd_kw_fprintf_grdecl(const rd_kw_type *rd_kw, FILE *stream,
+                          const char *special_header = nullptr) {
     if (special_header)
         fprintf(stream, "%s\n", special_header);
     else
@@ -504,8 +505,4 @@ void rd_kw_fprintf_grdecl__(const rd_kw_type *rd_kw, const char *special_header,
         fortio_free_FILE_wrapper(fortio);
     }
     fprintf(stream, "/\n");
-}
-
-void rd_kw_fprintf_grdecl(const rd_kw_type *rd_kw, FILE *stream) {
-    rd_kw_fprintf_grdecl__(rd_kw, NULL, stream);
 }

--- a/lib/resdata/rd_kw_grdecl.cpp
+++ b/lib/resdata/rd_kw_grdecl.cpp
@@ -1,6 +1,7 @@
 #include <cstring>
 #include <cctype>
 #include <optional>
+#include <memory>
 
 #include <ert/util/util.hpp>
 
@@ -417,11 +418,11 @@ void rd_kw_fprintf_grdecl(const rd_kw_type *rd_kw, FILE *stream,
         fprintf(stream, "%s\n", rd_kw_get_header(rd_kw));
 
     {
-        fortio_type *fortio = fortio_alloc_FILE_wrapper(
-            NULL, false, true, true,
-            stream); /* Endian flip should *NOT* be used */
-        rd_kw_fwrite_data(rd_kw, fortio);
-        fortio_free_FILE_wrapper(fortio);
+        auto fortio =
+            std::unique_ptr<fortio_type, decltype(&fortio_free_FILE_wrapper)>(
+                fortio_alloc_FILE_wrapper(nullptr, false, true, true, stream),
+                &fortio_free_FILE_wrapper);
+        rd_kw_fwrite_data(rd_kw, fortio.get());
     }
     fprintf(stream, "/\n");
 }

--- a/lib/resdata/rd_kw_grdecl.cpp
+++ b/lib/resdata/rd_kw_grdecl.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include <ert/util/util.hpp>
+#include <fmt/format.h>
 
 #include <resdata/rd_kw.hpp>
 #include <resdata/rd_type.hpp>
@@ -280,9 +281,11 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
                     else {
                         char_input = true;
                         if (strict)
-                            util_abort("%s: Malformed content:\"%s\" when "
-                                       "reading keyword:%s \n",
-                                       __func__, buffer.get(), header);
+                            throw std::invalid_argument(
+                                fmt::format("Malformed content:\"{}\" when "
+                                            "reading keyword:{}",
+                                            std::string(buffer.get()),
+                                            std::string(header)));
                     }
                 } else if (rd_type_is_float(data_type)) {
                     if (sscanf(buffer.get(), "%d*%128g", &multiplier,
@@ -292,9 +295,11 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
                     else {
                         char_input = true;
                         if (strict)
-                            util_abort("%s: Malformed content:\"%s\" when "
-                                       "reading keyword:%s \n",
-                                       __func__, buffer.get(), header);
+                            throw std::invalid_argument(
+                                fmt::format("Malformed content:\"{}\" when "
+                                            "reading keyword:{}",
+                                            std::string(buffer.get()),
+                                            std::string(header)));
                     }
                 } else if (rd_type_is_double(data_type)) {
                     if (sscanf(buffer.get(), "%d*%128lg", &multiplier,
@@ -304,13 +309,15 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
                     else {
                         char_input = true;
                         if (strict)
-                            util_abort("%s: Malformed content:\"%s\" when "
-                                       "reading keyword:%s \n",
-                                       __func__, buffer.get(), header);
+                            throw std::invalid_argument(
+                                fmt::format("Malformed content:\"{}\" when "
+                                            "reading keyword:{}",
+                                            std::string(buffer.get()),
+                                            std::string(header)));
                     }
                 } else
-                    util_abort("%s: sorry type:%s not supported \n", __func__,
-                               rd_type_alloc_name(data_type));
+                    throw std::invalid_argument(fmt::format(
+                        "Type:{} not supported", rd_type_name(data_type)));
 
                 // Removing this warning on user request:
                 // if (char_input)
@@ -397,13 +404,13 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw,
                                       rd_data_type data_type, int size = 0,
                                       bool strict = true) {
     if (kw && strlen(kw) >= MAX_GRDECL_HEADER_SIZE)
-        util_abort(
-            "%s cannot read KW of more than %d bytes. strlen(kw) == %d\n",
-            __func__, MAX_GRDECL_HEADER_SIZE, strlen(kw));
+        throw std::invalid_argument(fmt::format(
+            "Cannot read KW of more than {} bytes. strlen(kw) == {}",
+            MAX_GRDECL_HEADER_SIZE, strlen(kw)));
 
     if (!rd_type_is_numeric(data_type))
-        util_abort("%s: sorry only types FLOAT, INT and DOUBLE supported\n",
-                   __func__);
+        throw std::invalid_argument(
+            "Only types FLOAT, INT and DOUBLE supported");
 
     if (kw != NULL)
         if (!rd_kw_grdecl_fseek_kw(kw, true, stream))
@@ -420,9 +427,10 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw,
             if (size > 0)
                 if (size != kw_size) {
                     free(data);
-                    util_abort("%s: size mismatch when loading:%s. File:%d "
-                               "elements. Requested:%d elements \n",
-                               __func__, file_header, kw_size, size);
+                    throw std::invalid_argument(
+                        fmt::format("size mismatch when loading:{}. File:{} "
+                                    "elements. Requested:{} elements",
+                                    file_header, kw_size, size));
                 }
 
             {

--- a/lib/resdata/rd_kw_grdecl.cpp
+++ b/lib/resdata/rd_kw_grdecl.cpp
@@ -53,45 +53,36 @@
   current line is skipped. Lines starting with the "--" comment marker
   are ignored.
 */
-
 static bool rd_kw_grdecl_fseek_next_kw(FILE *stream) {
     long start_pos = util_ftell(stream);
     long current_pos;
     char next_kw[MAX_GRDECL_HEADER_SIZE] = {0};
 
-    /*
-    Determine if the current position of the file pointer is at the
-    beginning of the line; if not skip the rest of the line; this is
-    applies even though the tokens leading up this are not comments.
-  */
+    // Determine if the current position of the file pointer is at the
+    // beginning of the line; if not skip the rest of the line; this is
+    // applies even though the tokens leading up this are not comments.
     {
         while (true) {
             char c;
             if (util_ftell(stream) == 0)
-                /*
-          We are at the very beginning of the file. Can just jump out of
-          the loop.
-        */
+                // We are at the very beginning of the file. Can just jump out
+                // of the loop.
                 break;
 
             util_fseek(stream, -1, SEEK_CUR);
             c = fgetc(stream);
             if (c == '\n') {
-                /*
-           We have walked backwards reaching the start of the line. We
-           have not reached any !isspace() characters on the way and
-           can go back to start_pos and read from there.
-        */
+                // We have walked backwards reaching the start of the line. We
+                // have not reached any !isspace() characters on the way and
+                // can go back to start_pos and read from there.
                 util_fseek(stream, start_pos, SEEK_SET);
                 break;
             }
 
             if (!isspace(c)) {
-                /*
-           We hit a non-whitespace character; this means that start_pos
-           was not at the start of the line. We skip the rest of this
-           line, and then start reading on the next line.
-        */
+                // We hit a non-whitespace character; this means that start_pos
+                // was not at the start of the line. We skip the rest of this
+                // line, and then start reading on the next line.
                 util_fskip_lines(stream, 1);
                 break;
             }
@@ -130,7 +121,6 @@ static bool rd_kw_grdecl_fseek_next_kw(FILE *stream) {
 
   If the kw is not found the file pointer is repositioned.
 */
-
 static bool rd_kw_grdecl_fseek_kw__(const char *kw, FILE *stream) {
     long init_pos = util_ftell(stream);
     while (true) {
@@ -151,7 +141,7 @@ static bool rd_kw_grdecl_fseek_kw__(const char *kw, FILE *stream) {
 
 bool rd_kw_grdecl_fseek_kw(const char *kw, bool rewind, FILE *stream) {
     if (rd_kw_grdecl_fseek_kw__(kw, stream))
-        return true; /* OK - we found the kw between current file pos and EOF. */
+        return true; /* We found the kw between current file pos and EOF. */
     else if (rewind) {
         long int init_pos = util_ftell(stream);
 
@@ -165,7 +155,7 @@ bool rd_kw_grdecl_fseek_kw(const char *kw, bool rewind, FILE *stream) {
                 SEEK_SET); /* Could not find it - reposition to initial position. */
     }
 
-    /* OK: If we are here - that means that we failed to find the kw. */
+    /* If we are here - that means that we failed to find the kw. */
     return false;
 }
 
@@ -173,7 +163,6 @@ bool rd_kw_grdecl_fseek_kw(const char *kw, bool rewind, FILE *stream) {
    Observe that this function does not preserve the '*' structure
    which (might) have been used in the input.
 */
-
 static void iset_range(char *data, int data_index, int sizeof_ctype,
                        void *value_ptr, int multiplier) {
     size_t byte_offset;
@@ -213,7 +202,6 @@ static void iset_range(char *data, int data_index, int sizeof_ctype,
 
    Observe that no-spaces-are-allowed-around-the-*
 */
-
 static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
                                       rd_data_type data_type, int *kw_size,
                                       FILE *stream) {
@@ -295,11 +283,9 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
                     util_abort("%s: sorry type:%s not supported \n", __func__,
                                rd_type_alloc_name(data_type));
 
-                /*
-          Removing this warning on user request:
-          if (char_input)
-          fprintf(stderr,"Warning: character string: \'%s\' ignored when reading keyword:%s \n",buffer , header);
-        */
+                // Removing this warning on user request:
+                // if (char_input)
+                // fprintf(stderr,"Warning: character string: \'%s\' ignored when reading keyword:%s \n",buffer , header);
                 if (!char_input) {
                     size_t min_size = data_index + multiplier;
                     if (min_size >= data_size) {
@@ -312,11 +298,9 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
 
                             data = (char *)util_realloc(data, byte_size);
                         } else {
-                            /*
-                We are asking for more elements than can possible be adressed in
-                an integer. Return NULL - and data size == 0; let calling scope
-                try to handle it.
-              */
+                            // We are asking for more elements than can possible
+                            // be adressed in an integer. Return NULL - and
+                            // data size == 0; let calling scope try to handle it.
                             data_index = 0;
                             break;
                         }
@@ -424,12 +408,6 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw,
             return NULL;
     }
 }
-
-/*
-  This method allows to write with a different header,
-  i.e. PORO_XXXX. This header is even allowed to break the 8 character
-  length limit; i.e. loading it back naively will fail.
-*/
 
 void rd_kw_fprintf_grdecl(const rd_kw_type *rd_kw, FILE *stream,
                           const char *special_header = nullptr) {

--- a/lib/resdata/rd_kw_grdecl.cpp
+++ b/lib/resdata/rd_kw_grdecl.cpp
@@ -484,26 +484,6 @@ rd_kw_type *rd_kw_fscanf_alloc_grdecl(FILE *stream, const char *kw, int size,
 }
 
 /*
-   This function will read and allocate the next keyword in the
-   file. This function does not take either kw or the size of the kw
-   as input, and has virtually zero possibilities to check what it is
-   doing. The function should only be used when you are certain
-   that the input file is well formatted.
-*/
-
-static rd_kw_type *rd_kw_fscanf_alloc_current_grdecl__(FILE *stream,
-                                                       bool strict,
-                                                       rd_data_type data_type) {
-    return __rd_kw_fscanf_alloc_grdecl__(stream, NULL, strict, 0, data_type);
-}
-
-rd_kw_type *rd_kw_fscanf_alloc_current_grdecl(FILE *stream,
-                                              rd_data_type data_type) {
-    bool strict = true;
-    return rd_kw_fscanf_alloc_current_grdecl__(stream, strict, data_type);
-}
-
-/*
   This method allows to write with a different header,
   i.e. PORO_XXXX. This header is even allowed to break the 8 character
   length limit; i.e. loading it back naively will fail.

--- a/lib/resdata/rd_kw_pybind.cpp
+++ b/lib/resdata/rd_kw_pybind.cpp
@@ -1,0 +1,48 @@
+#include <cstdint>
+#include <stdexcept>
+#include <optional>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <fmt/format.h>
+
+#include <resdata/rd_kw.hpp>
+#include <resdata/rd_kw_grdecl.hpp>
+#include <resdata/rd_type.hpp>
+
+namespace py = pybind11;
+
+namespace {
+template <typename T> T *from_cwrap(py::handle obj) {
+    if (obj.is_none())
+        return nullptr;
+
+    py::int_ address = obj.attr("_BaseCClass__c_pointer");
+    void *pointer = PyLong_AsVoidPtr(address.ptr());
+
+    return reinterpret_cast<T *>(pointer);
+}
+
+PYBIND11_MODULE(_kw, m) {
+    m.doc() = "pybind11 bindings between rd_kw.py and rd_kw.cpp";
+
+    m.def(
+        "_load_grdecl",
+        [](py::handle file, std::optional<std::string> kw, bool strict,
+           py::handle data_type) {
+            auto *stream = from_cwrap<FILE>(file);
+            auto *rd_data_type = from_cwrap<::rd_data_type>(data_type);
+            if (rd_data_type == nullptr)
+                throw std::invalid_argument("data_type must not be None");
+            if (kw.has_value())
+                return reinterpret_cast<std::uintptr_t>(
+                    rd_kw_fscanf_alloc_grdecl_dynamic__(stream, kw->c_str(),
+                                                        strict, *rd_data_type));
+            else
+                return reinterpret_cast<std::uintptr_t>(
+                    rd_kw_fscanf_alloc_grdecl_dynamic__(stream, nullptr, strict,
+                                                        *rd_data_type));
+        },
+        py::return_value_policy::reference);
+}
+} // namespace

--- a/lib/resdata/rd_kw_pybind.cpp
+++ b/lib/resdata/rd_kw_pybind.cpp
@@ -36,12 +36,12 @@ PYBIND11_MODULE(_kw, m) {
                 throw std::invalid_argument("data_type must not be None");
             if (kw.has_value())
                 return reinterpret_cast<std::uintptr_t>(
-                    rd_kw_fscanf_alloc_grdecl_dynamic__(stream, kw->c_str(),
-                                                        strict, *rd_data_type));
+                    rd_kw_fscanf_alloc_grdecl_dynamic(stream, kw->c_str(),
+                                                      strict, *rd_data_type));
             else
                 return reinterpret_cast<std::uintptr_t>(
-                    rd_kw_fscanf_alloc_grdecl_dynamic__(stream, nullptr, strict,
-                                                        *rd_data_type));
+                    rd_kw_fscanf_alloc_grdecl_dynamic(stream, nullptr, strict,
+                                                      *rd_data_type));
         },
         py::return_value_policy::reference);
 }

--- a/lib/resdata/rd_kw_pybind.cpp
+++ b/lib/resdata/rd_kw_pybind.cpp
@@ -49,5 +49,9 @@ PYBIND11_MODULE(_kw, m) {
         auto *kw = from_cwrap<rd_kw_type>(self);
         rd_kw_fprintf_grdecl(kw, stream);
     });
+    m.def("_fseek_grdecl", [](std::string name, bool rewind, py::handle file) {
+        auto *stream = from_cwrap<FILE>(file);
+        return rd_kw_grdecl_fseek_kw(name.c_str(), rewind, stream);
+    });
 }
 } // namespace

--- a/lib/resdata/rd_kw_pybind.cpp
+++ b/lib/resdata/rd_kw_pybind.cpp
@@ -36,12 +36,12 @@ PYBIND11_MODULE(_kw, m) {
                 throw std::invalid_argument("data_type must not be None");
             if (kw.has_value())
                 return reinterpret_cast<std::uintptr_t>(
-                    rd_kw_fscanf_alloc_grdecl_dynamic(stream, kw->c_str(),
-                                                      strict, *rd_data_type));
+                    rd_kw_fscanf_alloc_grdecl(stream, kw->c_str(),
+                                              *rd_data_type, 0, strict));
             else
                 return reinterpret_cast<std::uintptr_t>(
-                    rd_kw_fscanf_alloc_grdecl_dynamic(stream, nullptr, strict,
-                                                      *rd_data_type));
+                    rd_kw_fscanf_alloc_grdecl(stream, nullptr, *rd_data_type, 0,
+                                              strict));
         },
         py::return_value_policy::reference);
     m.def("_fprintf_grdecl", [](py::handle self, py::handle file) {

--- a/lib/resdata/rd_kw_pybind.cpp
+++ b/lib/resdata/rd_kw_pybind.cpp
@@ -44,5 +44,10 @@ PYBIND11_MODULE(_kw, m) {
                                                       *rd_data_type));
         },
         py::return_value_policy::reference);
+    m.def("_fprintf_grdecl", [](py::handle self, py::handle file) {
+        auto *stream = from_cwrap<FILE>(file);
+        auto *kw = from_cwrap<rd_kw_type>(self);
+        rd_kw_fprintf_grdecl(kw, stream);
+    });
 }
 } // namespace

--- a/lib/resdata/rd_type.cpp
+++ b/lib/resdata/rd_type.cpp
@@ -2,6 +2,8 @@
 #include <cstring>
 #include <cctype>
 
+#include <fmt/format.h>
+
 #include <ert/util/util.hpp>
 #include <resdata/rd_type.hpp>
 
@@ -90,6 +92,29 @@ char *rd_type_alloc_name(const rd_data_type rd_type) {
         util_abort("Internal error in %s - internal eclipse_type: %d not "
                    "recognized - aborting \n",
                    __func__, rd_type.type);
+    }
+}
+
+std::string rd_type_name(const rd_data_type rd_type) {
+    switch (rd_type.type) {
+    case (RD_CHAR_TYPE):
+        return RD_TYPE_NAME_CHAR;
+    case (RD_STRING_TYPE):
+        return fmt::format("C{:03}", rd_type_get_sizeof_iotype(rd_type));
+    case (RD_FLOAT_TYPE):
+        return RD_TYPE_NAME_FLOAT;
+    case (RD_DOUBLE_TYPE):
+        return RD_TYPE_NAME_DOUBLE;
+    case (RD_INT_TYPE):
+        return RD_TYPE_NAME_INT;
+    case (RD_BOOL_TYPE):
+        return RD_TYPE_NAME_BOOL;
+    case (RD_MESS_TYPE):
+        return RD_TYPE_NAME_MESSAGE;
+    default:
+        throw std::invalid_argument(fmt::format("internal eclipse_type: {} not "
+                                                "recognized",
+                                                rd_type.type));
     }
 }
 

--- a/lib/resdata/rd_type.cpp
+++ b/lib/resdata/rd_type.cpp
@@ -61,10 +61,8 @@ rd_data_type rd_type_create_from_type(const rd_type_enum type) {
         util_abort("%s: Variable length string type cannot be created"
                    " from type alone!\n",
                    __func__);
-        return RD_STRING(0); /* Dummy */
     default:
         util_abort("%s: invalid rd_type: %d\n", __func__, type);
-        return RD_INT; /* Dummy */
     }
 }
 
@@ -92,7 +90,6 @@ char *rd_type_alloc_name(const rd_data_type rd_type) {
         util_abort("Internal error in %s - internal eclipse_type: %d not "
                    "recognized - aborting \n",
                    __func__, rd_type.type);
-        return NULL; /* Dummy */
     }
 }
 
@@ -113,7 +110,6 @@ rd_data_type rd_type_create_from_name(const char *type_name) {
         return RD_BOOL;
     else {
         util_abort("%s: unrecognized type name:%s \n", __func__, type_name);
-        return RD_INT; /* Dummy */
     }
 }
 

--- a/lib/resdata/rd_type_python.cpp
+++ b/lib/resdata/rd_type_python.cpp
@@ -86,16 +86,6 @@ bool rd_type_is_string_python(const rd_data_type *rd_type) {
     return rd_type_is_string(*rd_type);
 }
 
-/**
- *
- * Functions for the ResdataKw prototype
- *
- */
-rd_kw_type *rd_kw_fscanf_alloc_grdecl_dynamic_python(
-    FILE *stream, const char *kw, bool strict, const rd_data_type *data_type) {
-    return rd_kw_fscanf_alloc_grdecl_dynamic__(stream, kw, strict, *data_type);
-}
-
 rd_kw_type *rd_kw_alloc_python(const char *header, int size,
                                const rd_data_type *data_type) {
     return rd_kw_alloc(header, size, *data_type);

--- a/lib/resdata/tests/rd_fault_block_layer_equinor.cpp
+++ b/lib/resdata/tests/rd_fault_block_layer_equinor.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
     {
         FILE *stream = util_fopen(fault_blk_file, "r");
         fault_blk_kw = rd_kw_fscanf_alloc_grdecl(
-            stream, "FAULTBLK", rd_grid_get_global_size(rd_grid), RD_INT);
+            stream, "FAULTBLK", RD_INT, rd_grid_get_global_size(rd_grid));
         fclose(stream);
     }
 

--- a/lib/resdata/tests/rd_fault_block_layer_equinor.cpp
+++ b/lib/resdata/tests/rd_fault_block_layer_equinor.cpp
@@ -5,6 +5,7 @@
 
 #include <resdata/rd_grid.hpp>
 #include <resdata/rd_kw.hpp>
+#include <resdata/rd_kw_grdecl.hpp>
 #include <resdata/fault_block_layer.hpp>
 
 void test_create(rd_grid_type *grid, const rd_kw_type *fault_block_kw) {

--- a/lib/resdata/tests/rd_kw_fread.cpp
+++ b/lib/resdata/tests/rd_kw_fread.cpp
@@ -6,6 +6,7 @@
 
 #include <resdata/rd_endian_flip.hpp>
 #include <resdata/rd_kw.hpp>
+#include <resdata/rd_kw_grdecl.hpp>
 #include <resdata/FortIO.hpp>
 #include <resdata/rd_file.hpp>
 #include <resdata/rd_file_view.hpp>

--- a/lib/resdata/tests/rd_kw_fread.cpp
+++ b/lib/resdata/tests/rd_kw_fread.cpp
@@ -89,7 +89,7 @@ void test_kw_io_charlength() {
         {
             FILE *file = util_fopen("TEST2", "r");
             rd_kw_type *rd_kw_in =
-                rd_kw_fscanf_alloc_grdecl(file, KW1, -1, RD_FLOAT);
+                rd_kw_fscanf_alloc_grdecl(file, KW1, RD_FLOAT, -1);
             test_assert_string_equal(KW1, rd_kw_get_header(rd_kw_in));
             test_assert_int_equal(5, rd_kw_get_size(rd_kw_in));
 

--- a/lib/resdata/tests/rd_kw_grdecl.cpp
+++ b/lib/resdata/tests/rd_kw_grdecl.cpp
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
         fclose(stream);
 
         stream = util_fopen("FILE.grdecl", "w");
-        rd_kw_fprintf_grdecl__(rd_kw, "HEAD1234", stream);
+        rd_kw_fprintf_grdecl(rd_kw, stream, "HEAD1234");
         fclose(stream);
 
         stream = util_fopen("FILE.grdecl", "r");

--- a/lib/resdata/tests/rd_kw_grdecl.cpp
+++ b/lib/resdata/tests/rd_kw_grdecl.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
         stream = util_fopen("FILE.grdecl", "r");
         {
             rd_kw_type *rd_kw2 =
-                rd_kw_fscanf_alloc_grdecl(stream, "HEAD", 10, RD_INT);
+                rd_kw_fscanf_alloc_grdecl(stream, "HEAD", RD_INT, 10);
 
             test_assert_not_NULL(rd_kw2);
             test_assert_true(rd_kw_equal(rd_kw, rd_kw2));
@@ -39,10 +39,10 @@ int main(int argc, char **argv) {
         stream = util_fopen("FILE.grdecl", "r");
         {
             rd_kw_type *rd_kw2 =
-                rd_kw_fscanf_alloc_grdecl(stream, "HEAD", 10, RD_INT);
+                rd_kw_fscanf_alloc_grdecl(stream, "HEAD", RD_INT, 10);
 
             test_assert_NULL(rd_kw2);
-            rd_kw2 = rd_kw_fscanf_alloc_grdecl(stream, "HEAD1234", 10, RD_INT);
+            rd_kw2 = rd_kw_fscanf_alloc_grdecl(stream, "HEAD1234", RD_INT, 10);
             test_assert_not_NULL(rd_kw2);
 
             test_assert_string_equal(rd_kw_get_header(rd_kw2), "HEAD1234");

--- a/lib/resdata/tests/rd_kw_grdecl.cpp
+++ b/lib/resdata/tests/rd_kw_grdecl.cpp
@@ -5,6 +5,7 @@
 #include <ert/util/test_work_area.hpp>
 
 #include <resdata/rd_kw.hpp>
+#include <resdata/rd_kw_grdecl.hpp>
 
 int main(int argc, char **argv) {
     int i;

--- a/lib/resdata/tests/rd_layer_equinor.cpp
+++ b/lib/resdata/tests/rd_layer_equinor.cpp
@@ -7,6 +7,7 @@
 
 #include <resdata/rd_grid.hpp>
 #include <resdata/rd_kw.hpp>
+#include <resdata/rd_kw_grdecl.hpp>
 #include <resdata/layer.hpp>
 
 #include "detail/resdata/layer_cxx.hpp"

--- a/lib/resdata/tests/rd_layer_equinor.cpp
+++ b/lib/resdata/tests/rd_layer_equinor.cpp
@@ -15,7 +15,7 @@
 rd_kw_type *alloc_faultblock_kw(const char *filename, int grid_size) {
     FILE *stream = util_fopen(filename, "r");
     rd_kw_type *kw =
-        rd_kw_fscanf_alloc_grdecl(stream, "FAULTBLK", grid_size, RD_INT);
+        rd_kw_fscanf_alloc_grdecl(stream, "FAULTBLK", RD_INT, grid_size);
     fclose(stream);
 
     return kw;

--- a/lib/tests/test_rd_grid_misc.cpp
+++ b/lib/tests/test_rd_grid_misc.cpp
@@ -121,7 +121,7 @@ TEST_CASE_METHOD(Tmpdir, "Test grid file I/O", "[unittest]") {
                         fclose(f);
                 });
             return rd_kw_ptr(
-                rd_kw_fscanf_alloc_grdecl(fp.get(), kw, size, data_type),
+                rd_kw_fscanf_alloc_grdecl(fp.get(), kw, data_type, size),
                 &rd_kw_free);
         };
 

--- a/python/resdata/resfile/rd_kw.py
+++ b/python/resdata/resfile/rd_kw.py
@@ -114,7 +114,6 @@ class ResdataKW(BaseCClass):
         "rd_kw_obj rd_kw_alloc_slice_copy(rd_kw, int, int, int)"
     )
     _global_copy = ResdataPrototype("rd_kw_obj rd_kw_alloc_global_copy(rd_kw, rd_kw)")
-    _fprintf_grdecl = ResdataPrototype("void     rd_kw_fprintf_grdecl(rd_kw, FILE)")
     _fprintf_data = ResdataPrototype("void     rd_kw_fprintf_data(rd_kw, char*, FILE)")
 
     _get_size = ResdataPrototype("int      rd_kw_get_size(rd_kw)")
@@ -1137,7 +1136,7 @@ class ResdataKW(BaseCClass):
 
         """
         cfile = CFILE(file)
-        self._fprintf_grdecl(cfile)
+        _kw._fprintf_grdecl(self, cfile)
 
     def fprintf_data(self, file, fmt=None):
         """

--- a/python/resdata/resfile/rd_kw.py
+++ b/python/resdata/resfile/rd_kw.py
@@ -102,10 +102,6 @@ class ResdataKW(BaseCClass):
     _fread_alloc = ResdataPrototype(
         "rd_kw_obj rd_kw_fread_alloc(rd_fortio)", bind=False
     )
-    _fseek_grdecl = ResdataPrototype(
-        "bool     rd_kw_grdecl_fseek_kw(char*, bool, FILE)", bind=False
-    )
-
     _sub_copy = ResdataPrototype(
         "rd_kw_obj rd_kw_alloc_sub_copy(rd_kw, char*, int, int)"
     )
@@ -369,7 +365,7 @@ class ResdataKW(BaseCClass):
         search from there after the initial search.
         """
         cfile = CFILE(fileH)
-        return cls._fseek_grdecl(kw, rewind, cfile)
+        return _kw._fseek_grdecl(kw, rewind, cfile)
 
     @classmethod
     def fread(cls, fortio):

--- a/python/resdata/resfile/rd_kw.py
+++ b/python/resdata/resfile/rd_kw.py
@@ -252,7 +252,7 @@ class ResdataKW(BaseCClass):
         file. The @kw argument should be the keyword header you are
         searching for, e.g. "PORO" or "PVTNUM"[1], the method will
         then search forward through the file to look for this @kw. If
-        the keyword can not be found the method will return None. The
+        the keyword can not be found the method will raise ValueError. The
         searching will start from the current position in the file; so
         if you want to reposition the file pointer you should use the
         seek() method of the file object first.

--- a/python/resdata/resfile/rd_kw.py
+++ b/python/resdata/resfile/rd_kw.py
@@ -25,12 +25,13 @@ the resdata library.
 
 import ctypes
 import warnings
-from typing_extensions import deprecated
+from typing_extensions import deprecated, Self
 
 import numpy as np
 from cwrap import CFILE, BaseCClass
 from resdata import ResdataPrototype, ResDataType, ResdataTypeEnum
 from resdata.util.util import monkey_the_camel
+import resdata.resfile._kw as _kw
 
 
 def dump_type_deprecation_warning():
@@ -100,10 +101,6 @@ class ResdataKW(BaseCClass):
     )
     _fread_alloc = ResdataPrototype(
         "rd_kw_obj rd_kw_fread_alloc(rd_fortio)", bind=False
-    )
-    _load_grdecl = ResdataPrototype(
-        "rd_kw_obj rd_kw_fscanf_alloc_grdecl_dynamic_python(FILE, char*, bool, rd_data_type)",
-        bind=False,
     )
     _fseek_grdecl = ResdataPrototype(
         "bool     rd_kw_grdecl_fseek_kw(char*, bool, FILE)", bind=False
@@ -240,7 +237,13 @@ class ResdataKW(BaseCClass):
         return self._copyc()
 
     @classmethod
-    def read_grdecl(cls, fileH, kw, strict=True, rd_type=None):
+    def read_grdecl(
+        cls,
+        fileH,
+        kw: str | None,
+        strict: bool = True,
+        rd_type: ResDataType | None = None,
+    ) -> Self:
         """
         Function to load an ResdataKW instance from a grdecl formatted filehandle.
 
@@ -336,6 +339,10 @@ class ResdataKW(BaseCClass):
             )
 
         return cls._load_grdecl(cfile, kw, strict, rd_type)
+
+    @classmethod
+    def _load_grdecl(cls, cfile, kw, strict, rd_type):
+        return cls.createPythonObject(_kw._load_grdecl(cfile, kw, strict, rd_type))
 
     @classmethod
     def fseek_grdecl(cls, fileH, kw, rewind=False):

--- a/python/resdata/resfile/rd_kw.py
+++ b/python/resdata/resfile/rd_kw.py
@@ -953,6 +953,8 @@ class ResdataKW(BaseCClass):
         Will raise TypeError exception if the keyword is not of
         numerical type.
         """
+        if len(self) == 0:
+            return (np.nan, np.nan)
         if self.data_type.is_float():
             min_ = ctypes.c_float()
             max_ = ctypes.c_float()
@@ -1084,8 +1086,11 @@ class ResdataKW(BaseCClass):
                 "Invalid type - numpy array only valid for int/float/double"
             )
 
-        ap = ctypes.cast(self.data_ptr, ctypes.POINTER(ct * len(self)))
-        return np.frombuffer(ap.contents, dtype=self.dtype)
+        if len(self):
+            ap = ctypes.cast(self.data_ptr, ctypes.POINTER(ct * len(self)))
+            return np.frombuffer(ap.contents, dtype=self.dtype)
+        else:
+            return np.array([], dtype=self.dtype)
 
     def numpy_copy(self):
         """Will return a numpy array which contains a copy of the ResdataKW data.

--- a/tests/rd_tests/test_rd_kw.py
+++ b/tests/rd_tests/test_rd_kw.py
@@ -4,6 +4,7 @@ import random
 import warnings
 import cwrap
 import resfo
+import os
 from hypothesis import assume, settings
 import hypothesis.strategies as st
 from hypothesis.extra.numpy import arrays, from_dtype
@@ -764,13 +765,13 @@ array_shapes = st.integers(min_value=1, max_value=32).map(lambda n: (n,))
 int_arrays = arrays(dtype=np.int32, shape=array_shapes)
 float_arrays = arrays(
     dtype=np.float32,
-    elements=st.floats(width=32, allow_nan=False, allow_infinity=False),
+    elements=st.floats(width=32, min_value=-1e7, max_value=1e7),
     shape=array_shapes,
 )
 
 double_arrays = arrays(
     dtype=np.float64,
-    elements=st.floats(width=64, min_value=-1e100, max_value=1e100),
+    elements=st.floats(width=64, min_value=-1e10, max_value=1e10),
     shape=array_shapes,
 )
 
@@ -798,12 +799,17 @@ def write_with_resfo_and_read_with_resdata(res_data, format):
 
 
 def read_grdecl_from_text(rd_type, text):
-    kw_name = text.split()[0]
-    with tempfile.NamedTemporaryFile("w", suffix=".grdecl", delete=False) as f:
-        f.write(text)
+    fname = None
+    try:
+        with tempfile.NamedTemporaryFile("w", suffix=".grdecl", delete=False) as f:
+            f.write(text)
+            fname = f.name
 
         with cwrap.open(f.name, "r") as fh:
-            kw = ResdataKW.read_grdecl(fh, kw_name, rd_type=rd_type)
+            kw = ResdataKW.read_grdecl(fh, None, rd_type=rd_type)
+    finally:
+        if fname:
+            os.unlink(fname)
 
     return kw
 
@@ -851,6 +857,10 @@ POS_INT: /[1-9][0-9]{0,2}/
 COMMENT: /--[ \t][ \ta-zA-Z0-9]{0,20}\n/
 _WS: /[ \t\n]+/
 """)
+
+
+def order_of(values):
+    return np.linalg.norm(values, ord=np.inf)
 
 
 @settings(max_examples=100, suppress_health_check=["filter_too_much"])
@@ -989,19 +999,21 @@ class StatefulKwTest(RuleBasedStateMachine):
             npt.assert_allclose(cp, model_values, rtol=1e-2, atol=1e-6)
 
         # mutating the copy must not change original
-        original_first = actual_kw[0]
-        if model_values.dtype == np.int32:
-            cp[0] = cp[0] + 1
-        else:
-            cp[0] = cp[0] + 1.0
-        after_first = actual_kw[0]
-        assert (np.isnan(after_first) and np.isnan(original_first)) or (
-            after_first == pytest.approx(original_first, rel=1e-6, abs=1e-6)
-        )
+        if len(actual_kw):
+            original_first = actual_kw[0]
+            if model_values.dtype == np.int32:
+                cp[0] = cp[0] + 1
+            else:
+                cp[0] = cp[0] + 1.0
+            after_first = actual_kw[0]
+            assert (np.isnan(after_first) and np.isnan(original_first)) or (
+                after_first == pytest.approx(original_first, rel=1e-6, abs=1e-6)
+            )
 
     @rule(kw=numeric_kws)
     def get_min_max(self, kw):
         actual_kw, (_, model_values) = kw
+        assume(len(model_values))
         mn = actual_kw.get_min()
         mx = actual_kw.get_max()
         amn, amx = actual_kw.get_min_max()
@@ -1069,6 +1081,7 @@ class StatefulKwTest(RuleBasedStateMachine):
     @rule(data=st.data(), kw=st.one_of(numeric_kws, str_kws))
     def slice(self, data, kw):
         actual_kw, (_, model_values) = kw
+        assume(len(model_values) >= 1)
         start = data.draw(st.integers(min_value=0, max_value=len(model_values) - 1))
         stop = data.draw(st.integers(min_value=start, max_value=len(model_values)))
 
@@ -1130,15 +1143,14 @@ class StatefulKwTest(RuleBasedStateMachine):
         akw1.add_squared(akw2)
         model_values1 += model_values2 * model_values2
 
-        size_order = max(
-            1.0, np.max(np.abs(model_values2)), np.max(np.abs(model_values1))
-        )
+        size_order = max(1.0, order_of(model_values2), order_of(model_values1))
         npt.assert_allclose(akw1.numpy_view(), model_values1, atol=size_order * 1e-6)
         npt.assert_allclose(akw2.numpy_view(), model_values2, atol=size_order * 1e-6)
 
     @rule(data=st.data(), kw=numeric_kws)
     def setitem_numeric(self, data, kw):
         actual_kw, (_, model_values) = kw
+        assume(len(model_values) >= 1)
         i = data.draw(st.integers(min_value=0, max_value=len(model_values) - 1))
         av, v = self.draw_scalar(data, model_values.dtype)
 
@@ -1150,6 +1162,7 @@ class StatefulKwTest(RuleBasedStateMachine):
     @rule(data=st.data(), kw=str_kws)
     def setitem_str(self, data, kw):
         actual_kw, (_, model_values) = kw
+        assume(len(model_values) >= 1)
         i = data.draw(st.integers(min_value=0, max_value=len(model_values) - 1))
         elem_size = model_values.dtype.itemsize
         s = data.draw(keywords(size=elem_size))
@@ -1163,6 +1176,7 @@ class StatefulKwTest(RuleBasedStateMachine):
     def sub_copy(self, data, kw):
         actual_kw, (model_name, model_values) = kw
         n = len(model_values)
+        assume(n >= 1)
         offset = data.draw(st.integers(min_value=0, max_value=n - 1))
         count = data.draw(st.integers(min_value=1, max_value=n - offset))
         new_header = data.draw(st.one_of(st.none(), keywords(size=8)))
@@ -1203,7 +1217,7 @@ class StatefulKwTest(RuleBasedStateMachine):
         actual_kw += actual_delta
         model_values += delta
 
-        size_order = max(1.0, abs(delta), np.max(np.abs(model_values)))
+        size_order = max(1.0, abs(delta), order_of(model_values))
         npt.assert_allclose(
             actual_kw.numpy_view(), model_values, atol=size_order * 1e-6
         )
@@ -1216,7 +1230,7 @@ class StatefulKwTest(RuleBasedStateMachine):
         actual_kw -= actual_delta
         model_values -= delta
 
-        size_order = max(1.0, abs(delta), np.max(np.abs(model_values))) + 16
+        size_order = max(1.0, abs(delta), order_of(model_values)) + 16
         npt.assert_allclose(
             actual_kw.numpy_view(), model_values, atol=size_order * 1e-6
         )
@@ -1229,7 +1243,7 @@ class StatefulKwTest(RuleBasedStateMachine):
         actual_kw *= actual_factor
         model_values *= factor
 
-        size_order = max(1.0, abs(factor), np.max(abs(model_values)))
+        size_order = max(1.0, abs(factor), order_of(model_values))
         npt.assert_allclose(
             actual_kw.numpy_view(), model_values, atol=size_order * 1e-6
         )
@@ -1243,7 +1257,7 @@ class StatefulKwTest(RuleBasedStateMachine):
         akw1 -= akw2
         model_values1 -= model_values2
 
-        size_order = max(1.0, np.max(model_values1), np.max(abs(model_values2)))
+        size_order = max(1.0, order_of(model_values1), order_of(model_values2))
         npt.assert_allclose(akw1.numpy_view(), model_values1, atol=size_order * 1e-6)
         npt.assert_allclose(akw2.numpy_view(), model_values2, atol=size_order * 1e-6)
 
@@ -1255,7 +1269,7 @@ class StatefulKwTest(RuleBasedStateMachine):
         new_kw = actual_kw + actual_delta
         expected = model_values + delta
 
-        size_order = max(1.0, abs(delta), np.max(np.abs(model_values))) + 16
+        size_order = max(1.0, abs(delta), order_of(model_values)) + 16
         npt.assert_allclose(new_kw.numpy_view(), expected, atol=size_order * 1e-6)
         npt.assert_allclose(
             actual_kw.numpy_view(), model_values, atol=size_order * 1e-6
@@ -1269,7 +1283,7 @@ class StatefulKwTest(RuleBasedStateMachine):
         new_kw = actual_delta + actual_kw
         expected = delta + model_values
 
-        size_order = max(1.0, abs(delta), np.max(np.abs(model_values))) + 16
+        size_order = max(1.0, abs(delta), order_of(model_values)) + 16
         npt.assert_allclose(new_kw.numpy_view(), expected, atol=size_order * 1e-6)
         npt.assert_allclose(
             actual_kw.numpy_view(), model_values, atol=size_order * 1e-6
@@ -1283,7 +1297,7 @@ class StatefulKwTest(RuleBasedStateMachine):
         new_kw = actual_kw - actual_delta
         expected = model_values - delta
 
-        size_order = max(1.0, abs(delta), np.max(np.abs(model_values))) + 16
+        size_order = max(1.0, abs(delta), order_of(model_values)) + 16
         npt.assert_allclose(new_kw.numpy_view(), expected, atol=size_order * 1e-6)
         npt.assert_allclose(
             actual_kw.numpy_view(), model_values, atol=size_order * 1e-6
@@ -1298,7 +1312,7 @@ class StatefulKwTest(RuleBasedStateMachine):
         # __rsub__ is implemented as (self - delta) * -1
         expected = (model_values - delta) * -1
 
-        size_order = max(1.0, abs(delta), np.max(np.abs(model_values))) + 16
+        size_order = max(1.0, abs(delta), order_of(model_values)) + 16
         npt.assert_allclose(new_kw.numpy_view(), expected, atol=size_order * 1e-6)
         npt.assert_allclose(
             actual_kw.numpy_view(), model_values, atol=size_order * 1e-6
@@ -1312,7 +1326,7 @@ class StatefulKwTest(RuleBasedStateMachine):
         new_kw = actual_kw * actual_factor
         expected = model_values * factor
 
-        size_order = max(1.0, abs(factor), np.max(abs(model_values)))
+        size_order = max(1.0, abs(factor), order_of(model_values))
         npt.assert_allclose(new_kw.numpy_view(), expected, atol=size_order * 1e-6)
         npt.assert_allclose(
             actual_kw.numpy_view(), model_values, atol=size_order * 1e-6
@@ -1326,7 +1340,7 @@ class StatefulKwTest(RuleBasedStateMachine):
         new_kw = actual_factor * actual_kw
         expected = factor * model_values
 
-        size_order = max(1.0, abs(factor), np.max(abs(model_values)))
+        size_order = max(1.0, abs(factor), order_of(model_values))
         npt.assert_allclose(new_kw.numpy_view(), expected, atol=size_order * 1e-6)
         npt.assert_allclose(
             actual_kw.numpy_view(), model_values, atol=size_order * 1e-6
@@ -1353,6 +1367,7 @@ class StatefulKwTest(RuleBasedStateMachine):
     def first_different_self(self, kw):
         actual_kw, _ = kw
         cp = actual_kw.copy()
+        assume(len(actual_kw))
         assert actual_kw.first_different(cp) == len(actual_kw)
 
 

--- a/tests/rd_tests/test_rd_kw.py
+++ b/tests/rd_tests/test_rd_kw.py
@@ -710,6 +710,36 @@ def test_get_ptr_data():
     assert ResdataKW("KW1", 10, ResDataType.RD_DOUBLE).get_data_ptr()
 
 
+def _write_grdecl(tmp_path, name, body):
+    path = tmp_path / name
+    path.write_text(body)
+    return path
+
+
+def test_missing_keyword_raises(tmp_path):
+    path = _write_grdecl(tmp_path, "empty.grdecl", "PORO\n/\n")
+    with pytest.raises(ValueError), cwrap.open(str(path), "r") as fh:
+        _ = ResdataKW.read_grdecl(fh, "NOTPORO", rd_type=ResDataType.RD_FLOAT)
+
+
+def test_read_grdecl_empty_body_returns_zero_len_kw(tmp_path):
+    path = _write_grdecl(tmp_path, "empty.grdecl", "PORO\n/\n")
+    with cwrap.open(str(path), "r") as fh:
+        kw = ResdataKW.read_grdecl(fh, "PORO", rd_type=ResDataType.RD_FLOAT)
+    assert kw is not None
+    assert kw.name == "PORO"
+    assert len(kw) == 0
+
+
+def test_read_grdecl_kw_none_loads_first_keyword(tmp_path):
+    path = _write_grdecl(tmp_path, "first.grdecl", "PORO\n  0.1 0.2 0.3 /\n")
+    with cwrap.open(str(path), "r") as fh:
+        kw = ResdataKW.read_grdecl(fh, None, rd_type=ResDataType.RD_FLOAT)
+    assert kw is not None
+    assert kw.name == "PORO"
+    assert len(kw) == 3
+
+
 @st.composite
 def keywords(draw, size=8):
     return draw(
@@ -727,18 +757,6 @@ def str_arrays(draw):
     return draw(st.builds(np.array, st.lists(keywords(size), min_size=1))).astype(
         "|S" + str(size)
     )
-
-
-def _write_grdecl(tmp_path, name, body):
-    path = tmp_path / name
-    path.write_text(body)
-    return path
-
-
-def test_missing_keyword_raises(tmp_path):
-    path = _write_grdecl(tmp_path, "empty.grdecl", "PORO\n/\n")
-    with pytest.raises(ValueError), cwrap.open(str(path), "r") as fh:
-        _ = ResdataKW.read_grdecl(fh, "NOTPORO", rd_type=ResDataType.RD_FLOAT)
 
 
 array_shapes = st.integers(min_value=1, max_value=32).map(lambda n: (n,))

--- a/tests/rd_tests/test_rd_kw.py
+++ b/tests/rd_tests/test_rd_kw.py
@@ -729,6 +729,18 @@ def str_arrays(draw):
     )
 
 
+def _write_grdecl(tmp_path, name, body):
+    path = tmp_path / name
+    path.write_text(body)
+    return path
+
+
+def test_missing_keyword_raises(tmp_path):
+    path = _write_grdecl(tmp_path, "empty.grdecl", "PORO\n/\n")
+    with pytest.raises(ValueError), cwrap.open(str(path), "r") as fh:
+        _ = ResdataKW.read_grdecl(fh, "NOTPORO", rd_type=ResDataType.RD_FLOAT)
+
+
 array_shapes = st.integers(min_value=1, max_value=32).map(lambda n: (n,))
 
 int_arrays = arrays(dtype=np.int32, shape=array_shapes)

--- a/tests/rd_tests/test_rd_kw.py
+++ b/tests/rd_tests/test_rd_kw.py
@@ -741,6 +741,26 @@ def test_read_grdecl_kw_none_loads_first_keyword(tmp_path):
     assert len(kw) == 3
 
 
+def test_read_grdecl_int_strict_raises_on_malformed(tmp_path):
+    path = _write_grdecl(tmp_path, "intkw.grdecl", "INTKW\n  1 2 FOO 3 /\n")
+    with cwrap.open(str(path), "r") as fh:
+        with pytest.raises(
+            ValueError,
+            match=r'Malformed content:"FOO" when reading keyword:INTKW',
+        ):
+            ResdataKW.read_grdecl(fh, "INTKW", rd_type=ResDataType.RD_INT)
+
+
+def test_read_grdecl_float_strict_raises_on_malformed(tmp_path):
+    path = _write_grdecl(tmp_path, "fltkw.grdecl", "FLTKW\n  1.0 2.0 BAR 3.0 /\n")
+    with cwrap.open(str(path), "r") as fh:
+        with pytest.raises(
+            ValueError,
+            match=r'Malformed content:"BAR" when reading keyword:FLTKW',
+        ):
+            ResdataKW.read_grdecl(fh, "FLTKW", rd_type=ResDataType.RD_FLOAT)
+
+
 @st.composite
 def keywords(draw, size=8):
     return draw(


### PR DESCRIPTION
Also fixes a segfault for zero-length min_max.

With regards to returning None or not, I changed the documentation of "If the keyword can not be found the method will return None." This is because we consider this legacy code so its more likely that someone depends on behavior rather than documentation.