### PR TITLE
Backport to 6.2

### DIFF
--- a/lib/resdata/rd_grid.cpp
+++ b/lib/resdata/rd_grid.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <unordered_map>
 #include <string>
+#include <limits>
 
 #include <ert/util/util.hpp>
 #include <ert/util/double_vector.hpp>
@@ -2256,6 +2257,34 @@ static rd_grid_type *rd_grid_alloc_GRDECL_kw__(
     nz = rd_kw_iget_int(gridhead_kw, GRIDHEAD_NZ_INDEX);
     lgr_nr = rd_kw_iget_int(gridhead_kw, GRIDHEAD_LGR_INDEX);
 
+    if (nx <= 0 || ny <= 0 || nz <= 0)
+        util_abort("%s: Invalid grid dimensions: nx=%d, ny=%d, nz=%d\n",
+                   __func__, nx, ny, nz);
+
+    const int64_t nx64 = nx;
+    const int64_t ny64 = ny;
+    const int64_t nz64 = nz;
+    const int64_t expected_coord_size = int64_t{6} * (nx64 + 1) * (ny64 + 1);
+    const int64_t expected_zcorn_size = int64_t{8} * nx64 * ny64 * nz64;
+
+    if (expected_coord_size > std::numeric_limits<int>::max() ||
+        expected_zcorn_size > std::numeric_limits<int>::max())
+        util_abort("%s: Grid dimensions too large: nx=%d, ny=%d, nz=%d\n",
+                   __func__, nx, ny, nz);
+
+    const int coord_size = static_cast<int>(expected_coord_size);
+    const int zcorn_size = static_cast<int>(expected_zcorn_size);
+
+    if (rd_kw_get_size(coord_kw) != coord_size)
+        util_abort("%s: Invalid size of COORD keyword = %d, expected 6 * "
+                   "(nx + 1) * (ny + 1) = %d\n",
+                   __func__, rd_kw_get_size(coord_kw), coord_size);
+
+    if (rd_kw_get_size(zcorn_kw) != zcorn_size)
+        util_abort("%s: Invalid size of ZCORN keyword = %d, expected 8 * "
+                   "nx * ny * nz = %d\n",
+                   __func__, rd_kw_get_size(zcorn_kw), zcorn_size);
+
     /*
     The code used to have this test:
 
@@ -2318,8 +2347,21 @@ rd_grid_alloc_GRDECL_kw(int nx, int ny, int nz, const rd_kw_type *zcorn_kw,
                         const rd_kw_type *mapaxes_kw) { /* Can be NULL */
 
     const int *actnum_data = NULL;
-    if (actnum_kw)
+    if (actnum_kw) {
+        const int64_t expected_actnum_size = int64_t{nx} * ny * nz;
+
+        if (expected_actnum_size > std::numeric_limits<int>::max())
+            util_abort("%s: Grid dimensions too large: nx=%d, ny=%d, nz=%d\n",
+                       __func__, nx, ny, nz);
+
+        const int actnum_size = static_cast<int>(expected_actnum_size);
+
+        if (rd_kw_get_size(actnum_kw) != actnum_size)
+            util_abort("%s: Invalid size of ACTNUM keyword = %d, expected nz "
+                       "* nx * ny = %d\n",
+                       __func__, rd_kw_get_size(actnum_kw), actnum_size);
         actnum_data = rd_kw_get_int_ptr(actnum_kw);
+    }
 
     bool apply_mapaxes = true;
     rd_kw_type *gridhead_kw = rd_grid_alloc_gridhead_kw(nx, ny, nz, 0);

--- a/lib/resdata/rd_grid.cpp
+++ b/lib/resdata/rd_grid.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <cstdio>
 #include <cmath>
+#include <cinttypes>
 
 #include <vector>
 #include <unordered_map>
@@ -2303,11 +2304,24 @@ static rd_grid_type *rd_grid_alloc_GRDECL_kw__(
         const float *mapaxes_data = NULL;
         const int *corsnum_data = NULL;
 
-        if (mapaxes_kw)
+        if (mapaxes_kw) {
+            if (rd_kw_get_size(mapaxes_kw) != 6)
+                util_abort(
+                    "%s: Invalid size of MAPAXES keyword = %d, expected 6\n",
+                    __func__, rd_kw_get_size(mapaxes_kw));
             mapaxes_data = rd_grid_get_mapaxes_from_kw__(mapaxes_kw);
+        }
 
-        if (corsnum_kw)
+        if (corsnum_kw) {
+            const int64_t expected_corsnum_size = nx64 * ny64 * nz64;
+            if (expected_corsnum_size > std::numeric_limits<int>::max() ||
+                rd_kw_get_size(corsnum_kw) != expected_corsnum_size)
+                util_abort("%s: Invalid size of CORSNUM keyword = %d, expected "
+                           "nx * ny * nz = %" PRId64 "\n",
+                           __func__, rd_kw_get_size(corsnum_kw),
+                           expected_corsnum_size);
             corsnum_data = rd_kw_get_int_ptr(corsnum_kw);
+        }
 
         if (gridunit_kw)
             unit_system = rd_grid_check_unit_system(gridunit_kw);

--- a/lib/resdata/rd_kw.cpp
+++ b/lib/resdata/rd_kw.cpp
@@ -2317,6 +2317,9 @@ void rd_kw_max_min(const rd_kw_type *rd_kw, void *_max, void *_min) {
 #define RD_KW_MAX_MIN(ctype)                                                   \
     void rd_kw_max_min_##ctype(const rd_kw_type *rd_kw, ctype *_max,           \
                                ctype *_min) {                                  \
+        if (rd_kw->size < 1)                                                   \
+            util_abort("%s: size of zero length array is undefined \n",        \
+                       __func__);                                              \
         KW_MAX_MIN(ctype);                                                     \
     }
 

--- a/lib/resdata/rd_kw_grdecl.cpp
+++ b/lib/resdata/rd_kw_grdecl.cpp
@@ -219,7 +219,7 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
     char newline = '\n';
     bool atEOF = false;
     size_t init_size = 32;
-    size_t buffer_size = 64;
+    size_t buffer_size = 256;
     size_t data_index = 0;
     int sizeof_ctype = rd_type_get_sizeof_ctype(data_type);
     size_t data_size = init_size;
@@ -267,8 +267,9 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
                                        __func__, buffer, header);
                     }
                 } else if (rd_type_is_float(data_type)) {
-                    if (sscanf(buffer, "%d*%g", &multiplier, &value.f) == 2) {
-                    } else if (sscanf(buffer, "%g", &value.f) == 1)
+                    if (sscanf(buffer, "%d*%128g", &multiplier, &value.f) ==
+                        2) {
+                    } else if (sscanf(buffer, "%128g", &value.f) == 1)
                         multiplier = 1;
                     else {
                         char_input = true;
@@ -278,8 +279,9 @@ static char *fscanf_alloc_grdecl_data(const char *header, bool strict,
                                        __func__, buffer, header);
                     }
                 } else if (rd_type_is_double(data_type)) {
-                    if (sscanf(buffer, "%d*%lg", &multiplier, &value.d) == 2) {
-                    } else if (sscanf(buffer, "%lg", &value.d) == 1)
+                    if (sscanf(buffer, "%d*%128lg", &multiplier, &value.d) ==
+                        2) {
+                    } else if (sscanf(buffer, "%128lg", &value.d) == 1)
                         multiplier = 1;
                     else {
                         char_input = true;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ testpaths = ["tests"]
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
 build = "cp311-* cp312-* cp313-* cp314-*"
-skip = "*-musllinux_*"
+skip = "*-musllinux_* *-win32"
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y zlib-devel"

--- a/python/resdata/resfile/rd_kw.py
+++ b/python/resdata/resfile/rd_kw.py
@@ -954,6 +954,8 @@ class ResdataKW(BaseCClass):
         Will raise TypeError exception if the keyword is not of
         numerical type.
         """
+        if len(self) == 0:
+            return (np.nan, np.nan)
         if self.data_type.is_float():
             min_ = ctypes.c_float()
             max_ = ctypes.c_float()
@@ -1085,8 +1087,11 @@ class ResdataKW(BaseCClass):
                 "Invalid type - numpy array only valid for int/float/double"
             )
 
-        ap = ctypes.cast(self.data_ptr, ctypes.POINTER(ct * len(self)))
-        return np.frombuffer(ap.contents, dtype=self.dtype)
+        if len(self):
+            ap = ctypes.cast(self.data_ptr, ctypes.POINTER(ct * len(self)))
+            return np.frombuffer(ap.contents, dtype=self.dtype)
+        else:
+            return np.array([], dtype=self.dtype)
 
     def numpy_copy(self):
         """Will return a numpy array which contains a copy of the ResdataKW data.

--- a/tests/rd_tests/test_rd_kw.py
+++ b/tests/rd_tests/test_rd_kw.py
@@ -687,3 +687,20 @@ def test_get_ptr_data():
     assert ResdataKW("KW1", 10, ResDataType.RD_INT).get_data_ptr()
     assert ResdataKW("KW1", 10, ResDataType.RD_FLOAT).get_data_ptr()
     assert ResdataKW("KW1", 10, ResDataType.RD_DOUBLE).get_data_ptr()
+
+
+def _write_grdecl(tmp_path, name, body):
+    path = tmp_path / name
+    path.write_text(body)
+    return path
+
+
+def test_read_grdecl_empty_body_returns_zero_len_kw(tmp_path):
+    path = _write_grdecl(tmp_path, "empty.grdecl", "PORO\n/\n")
+    with cwrap.open(str(path), "r") as fh:
+        kw = ResdataKW.read_grdecl(fh, "PORO", rd_type=ResDataType.RD_FLOAT)
+    assert kw is not None
+    assert kw.name == "PORO"
+    assert len(kw) == 0
+    assert len(kw.numpy_view()) == 0
+    assert repr(kw).startswith('ResdataKW(size=0, name="PORO", min=nan, max=nan)')


### PR DESCRIPTION
Backports fixes that are on main branch to version 6.2 . The only difference is that throws are now util_abort. This is to avoid changes to the error handling semantics.