### PR TITLE
Make Catch2 a test only dependency

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-2022']
+        os: ['ubuntu-latest', 'macos-latest']
 
     runs-on: ${{ matrix.os }}
 
@@ -49,19 +49,12 @@ jobs:
       run: |
         python3 -m pip install -r requirements.txt
         mkdir cmake-build
-        conan install . --output-folder=cmake-build --build=missing
+        conan install . --output-folder=cmake-build --build=missing -o build_tests=True
 
-    - name: Build (Unix)
-      if: runner.os != 'Windows'
+    - name: Build
       run: |
-        cmake --preset conan-release -DBUILD_TESTS=ON -DENABLE_ASAN=ON -DENABLE_UBSAN=ON -DRST_DOC=ON
+        cmake --preset conan-release -DENABLE_ASAN=ON -DENABLE_UBSAN=ON -DRST_DOC=ON
         cmake --build --preset conan-release
-
-    - name: Build (Windows)
-      if: runner.os == 'Windows'
-      run: |
-        cmake --preset conan-default
-        cmake --build --preset conan-release -DRST_DOC=ON
 
     - name: Run tests
       run: |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Ensure that `cmake` and `conan` version 2 is installed.
 ```sh
 #set up conan
 conan profile detect
-conan install -of build --build=missing .
+conan install -of build --build=missing . -o build_tests=True
 cmake --preset=conan-release -DENABLE_ASAN=ON -DENABLE_UBSAN=ON
 
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,17 +1,28 @@
 from conan import ConanFile
+from conan.tools.cmake import CMakeDeps, CMakeToolchain
 
 
 class ResdataConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeDeps", "CMakeToolchain"
+    options = {"build_tests": [True, False]}
+    default_options = {"build_tests": False}
 
     def requirements(self):
         self.requires("backward-cpp/1.6")
-        self.requires("catch2/3.14.0")
         self.requires("fmt/8.0.1")
         self.requires("pybind11/3.0.1")
 
+        if self.options.build_tests:
+            self.requires("catch2/3.14.0")
+
     def configure(self):
-        self.options["catch2"].with_main = True
+        if self.options.build_tests:
+            self.options["catch2"].with_main = True
         if self.settings.os == "Macos":
             self.options["backward-cpp"].stack_details = "backtrace_symbol"
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["BUILD_TESTS"] = "ON" if self.options.build_tests else "OFF"
+        tc.generate()
+        CMakeDeps(self).generate()


### PR DESCRIPTION
This speeds up `pip install .` considerably.
