### PR TITLE
Check cwrap types when calling via pybind

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -163,7 +163,7 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/
 # -----------------------------------------------------------------
 set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
-pybind11_add_module(_grid resdata/rd_grid_pybind.cpp)
+pybind11_add_module(_grid resdata/rd_grid_pybind.cpp resdata/cwrap_pybind.cpp)
 target_link_libraries(_grid PRIVATE resdata fmt::fmt)
 target_include_directories(
   _grid
@@ -193,7 +193,7 @@ set_target_properties(
 # -----------------------------------------------------------------
 # Pybind11 extension module: resdata.resfile._kw
 # -----------------------------------------------------------------
-pybind11_add_module(_kw resdata/rd_kw_pybind.cpp)
+pybind11_add_module(_kw resdata/rd_kw_pybind.cpp resdata/cwrap_pybind.cpp)
 target_link_libraries(_kw PRIVATE resdata fmt::fmt)
 target_include_directories(
   _kw
@@ -222,7 +222,7 @@ set_target_properties(
 # -----------------------------------------------------------------
 # Pybind11 extension module: resdata.resfile._fortio
 # -----------------------------------------------------------------
-pybind11_add_module(_fortio resdata/fortio_pybind.cpp)
+pybind11_add_module(_fortio resdata/fortio_pybind.cpp resdata/cwrap_pybind.cpp)
 target_link_libraries(_fortio PRIVATE resdata fmt::fmt)
 target_include_directories(
   _fortio
@@ -248,7 +248,7 @@ set_target_properties(
 # -----------------------------------------------------------------
 # Pybind11 extension module: resdata.summary._rd_sum
 # -----------------------------------------------------------------
-pybind11_add_module(_rd_sum resdata/rd_sum_pybind.cpp)
+pybind11_add_module(_rd_sum resdata/rd_sum_pybind.cpp resdata/cwrap_pybind.cpp)
 target_link_libraries(_rd_sum PRIVATE resdata fmt::fmt)
 target_include_directories(
   _rd_sum

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -165,8 +165,11 @@ set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 pybind11_add_module(_grid resdata/rd_grid_pybind.cpp)
 target_link_libraries(_grid PRIVATE resdata fmt::fmt)
-target_include_directories(_grid PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-                                         ${CMAKE_CURRENT_BINARY_DIR}/include)
+target_include_directories(
+  _grid
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+          ${CMAKE_CURRENT_BINARY_DIR}/include
+          ${CMAKE_CURRENT_SOURCE_DIR}/private-include)
 if(SKBUILD)
   set(_grid_install_dir "python/resdata/grid")
   # libresdata.so.6 is installed at python/resdata/.libs/ make _grid.so find it
@@ -192,8 +195,11 @@ set_target_properties(
 # -----------------------------------------------------------------
 pybind11_add_module(_kw resdata/rd_kw_pybind.cpp)
 target_link_libraries(_kw PRIVATE resdata fmt::fmt)
-target_include_directories(_kw PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-                                       ${CMAKE_CURRENT_BINARY_DIR}/include)
+target_include_directories(
+  _kw
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+          ${CMAKE_CURRENT_BINARY_DIR}/include
+          ${CMAKE_CURRENT_SOURCE_DIR}/private-include)
 if(SKBUILD)
   set(_kw_install_dir "python/resdata/resfile")
   # libresdata.so.6 is installed at python/resdata/.libs/ make _kw.so find it
@@ -218,8 +224,11 @@ set_target_properties(
 # -----------------------------------------------------------------
 pybind11_add_module(_fortio resdata/fortio_pybind.cpp)
 target_link_libraries(_fortio PRIVATE resdata fmt::fmt)
-target_include_directories(_fortio PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-                                           ${CMAKE_CURRENT_BINARY_DIR}/include)
+target_include_directories(
+  _fortio
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+          ${CMAKE_CURRENT_BINARY_DIR}/include
+          ${CMAKE_CURRENT_SOURCE_DIR}/private-include)
 if(SKBUILD)
   set(_fortio_install_dir "python/resdata/resfile")
   if(APPLE)
@@ -241,8 +250,11 @@ set_target_properties(
 # -----------------------------------------------------------------
 pybind11_add_module(_rd_sum resdata/rd_sum_pybind.cpp)
 target_link_libraries(_rd_sum PRIVATE resdata fmt::fmt)
-target_include_directories(_rd_sum PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-                                           ${CMAKE_CURRENT_BINARY_DIR}/include)
+target_include_directories(
+  _rd_sum
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+          ${CMAKE_CURRENT_BINARY_DIR}/include
+          ${CMAKE_CURRENT_SOURCE_DIR}/private-include)
 if(SKBUILD)
   set(_rd_sum_install_dir "python/resdata/summary")
   if(APPLE)

--- a/lib/private-include/detail/resdata/cwrap_pybind.hpp
+++ b/lib/private-include/detail/resdata/cwrap_pybind.hpp
@@ -1,12 +1,8 @@
 #pragma once
 #include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
 
-template <typename T> T *from_cwrap(pybind11::handle obj) {
-    if (obj.is_none())
-        return nullptr;
+#include <resdata/rd_kw.hpp>
 
-    pybind11::int_ address = obj.attr("_BaseCClass__c_pointer");
-    void *pointer = PyLong_AsVoidPtr(address.ptr());
-
-    return reinterpret_cast<T *>(pointer);
-}
+template <typename T> T *from_cwrap(pybind11::handle obj);
+rd_kw_type *from_cwrap_opt_kw(pybind11::handle obj);

--- a/lib/private-include/detail/resdata/cwrap_pybind.hpp
+++ b/lib/private-include/detail/resdata/cwrap_pybind.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <pybind11/pybind11.h>
+
+template <typename T> T *from_cwrap(pybind11::handle obj) {
+    if (obj.is_none())
+        return nullptr;
+
+    pybind11::int_ address = obj.attr("_BaseCClass__c_pointer");
+    void *pointer = PyLong_AsVoidPtr(address.ptr());
+
+    return reinterpret_cast<T *>(pointer);
+}

--- a/lib/resdata/cwrap_pybind.cpp
+++ b/lib/resdata/cwrap_pybind.cpp
@@ -1,0 +1,185 @@
+#include <cstdio>
+#include <string>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+
+#include <resdata/rd_kw.hpp>
+#include <resdata/rd_grid.hpp>
+#include <resdata/rd_sum.hpp>
+#include <resdata/FortIO.hpp>
+
+#include <ert/util/double_vector.hpp>
+#include <ert/util/stringlist.hpp>
+#include <ert/util/time_t_vector.hpp>
+
+#include <detail/resdata/cwrap_pybind.hpp>
+
+namespace py = pybind11;
+
+template <typename T> T *cast_cwrap(py::handle obj) {
+    py::int_ address = obj.attr("_BaseCClass__c_pointer");
+    void *pointer = PyLong_AsVoidPtr(address.ptr());
+    return reinterpret_cast<T *>(pointer);
+}
+
+py::object ResdataKW() {
+    static py::object cls;
+    if (!cls) {
+        cls = py::module_::import("resdata.resfile").attr("ResdataKW");
+    }
+    return cls;
+}
+
+template <> rd_kw_type *from_cwrap<rd_kw_type>(py::handle obj) {
+    if (!py::isinstance(obj, ResdataKW()))
+        throw py::type_error("Expected ResdataKW, got " +
+                             static_cast<std::string>(py::repr(obj)));
+    return cast_cwrap<rd_kw_type>(obj);
+}
+
+rd_kw_type *from_cwrap_opt_kw(py::handle obj) {
+    if (obj.is_none())
+        return nullptr;
+
+    if (!py::isinstance(obj, ResdataKW()))
+        throw py::type_error("Expected ResdataKW, got " +
+                             static_cast<std::string>(py::repr(obj)));
+    return cast_cwrap<rd_kw_type>(obj);
+}
+
+py::object Grid() {
+    static py::object cls;
+    if (!cls) {
+        cls = py::module_::import("resdata.grid").attr("Grid");
+    }
+    return cls;
+}
+
+template <> rd_grid_type *from_cwrap<rd_grid_type>(py::handle obj) {
+    if (!py::isinstance(obj, Grid()))
+        throw py::type_error("Expected Grid, got " +
+                             static_cast<std::string>(py::repr(obj)));
+    return cast_cwrap<rd_grid_type>(obj);
+}
+
+py::object Summary() {
+    static py::object cls;
+    if (!cls) {
+        cls = py::module_::import("resdata.summary").attr("Summary");
+    }
+    return cls;
+}
+
+template <> rd_sum_type *from_cwrap<rd_sum_type>(py::handle obj) {
+    if (!py::isinstance(obj, Summary()))
+        throw py::type_error("Expected Summary, got " +
+                             static_cast<std::string>(py::repr(obj)));
+    return cast_cwrap<rd_sum_type>(obj);
+}
+
+py::object StringList() {
+    static py::object cls;
+    if (!cls) {
+        cls = py::module_::import("resdata.util.util").attr("StringList");
+    }
+    return cls;
+}
+
+template <> stringlist_type *from_cwrap<stringlist_type>(py::handle obj) {
+    if (!py::isinstance(obj, StringList()))
+        throw py::type_error("Expected StringList, got " +
+                             static_cast<std::string>(py::repr(obj)));
+    return cast_cwrap<stringlist_type>(obj);
+}
+
+py::object TimeVector() {
+    static py::object cls;
+    if (!cls) {
+        cls = py::module_::import("resdata.util.util").attr("TimeVector");
+    }
+    return cls;
+}
+
+template <> time_t_vector_type *from_cwrap<time_t_vector_type>(py::handle obj) {
+    if (!py::isinstance(obj, TimeVector()))
+        throw py::type_error("Expected TimeVector, got " +
+                             static_cast<std::string>(py::repr(obj)));
+    return cast_cwrap<time_t_vector_type>(obj);
+}
+
+py::object SummaryKeyWordVector() {
+    static py::object cls;
+    if (!cls) {
+        cls =
+            py::module_::import("resdata.summary").attr("SummaryKeyWordVector");
+    }
+    return cls;
+}
+
+template <> rd_sum_vector_type *from_cwrap<rd_sum_vector_type>(py::handle obj) {
+    if (!py::isinstance(obj, SummaryKeyWordVector()))
+        throw py::type_error("Expected SummaryKeyWordVector, got " +
+                             static_cast<std::string>(py::repr(obj)));
+    return cast_cwrap<rd_sum_vector_type>(obj);
+}
+
+py::object DoubleVector() {
+    static py::object cls;
+    if (!cls) {
+        cls = py::module_::import("resdata.util.util").attr("DoubleVector");
+    }
+    return cls;
+}
+
+template <> double_vector_type *from_cwrap<double_vector_type>(py::handle obj) {
+    if (!py::isinstance(obj, DoubleVector()))
+        throw py::type_error("Expected DoubleVector, got " +
+                             static_cast<std::string>(py::repr(obj)));
+    return cast_cwrap<double_vector_type>(obj);
+}
+
+py::object CFILE() {
+    static py::object cls;
+    if (!cls) {
+        cls = py::module_::import("cwrap.cfile").attr("CWrapFile");
+    }
+    return cls;
+}
+
+template <> FILE *from_cwrap<FILE>(py::handle obj) {
+    if (!py::isinstance(obj, CFILE()))
+        throw py::type_error("Expected CFILE, got " +
+                             static_cast<std::string>(py::repr(obj)));
+    return cast_cwrap<FILE>(obj);
+}
+
+py::object FortIO() {
+    static py::object cls;
+    if (!cls) {
+        cls = py::module_::import("resdata.resfile").attr("FortIO");
+    }
+    return cls;
+}
+
+template <> fortio_type *from_cwrap<fortio_type>(py::handle obj) {
+    if (!py::isinstance(obj, FortIO()))
+        throw py::type_error("Expected FortIO, got " +
+                             static_cast<std::string>(py::repr(obj)));
+    return cast_cwrap<fortio_type>(obj);
+}
+
+py::object ResDataType() {
+    static py::object cls;
+    if (!cls) {
+        cls = py::module_::import("resdata").attr("ResDataType");
+    }
+    return cls;
+}
+
+template <>::rd_data_type *from_cwrap<::rd_data_type>(py::handle obj) {
+    if (!py::isinstance(obj, ResDataType()))
+        throw py::type_error("Expected ResDataType, got " +
+                             static_cast<std::string>(py::repr(obj)));
+    return cast_cwrap<::rd_data_type>(obj);
+}

--- a/lib/resdata/fortio_pybind.cpp
+++ b/lib/resdata/fortio_pybind.cpp
@@ -3,19 +3,11 @@
 
 #include <resdata/FortIO.hpp>
 
+#include <detail/resdata/cwrap_pybind.hpp>
+
 namespace py = pybind11;
 
 namespace {
-template <typename T> T *from_cwrap(py::handle obj) {
-    if (obj.is_none())
-        return nullptr;
-
-    py::int_ address = obj.attr("_BaseCClass__c_pointer");
-    void *pointer = PyLong_AsVoidPtr(address.ptr());
-
-    return reinterpret_cast<T *>(pointer);
-}
-
 PYBIND11_MODULE(_fortio, m) {
     m.doc() = "pybind11 bindings between fortio.py and FortIO.cpp";
 

--- a/lib/resdata/rd_grid_pybind.cpp
+++ b/lib/resdata/rd_grid_pybind.cpp
@@ -32,8 +32,8 @@ PYBIND11_MODULE(_grid, m) {
            py::handle actnum, py::handle mapaxes) {
             return reinterpret_cast<std::uintptr_t>(rd_grid_alloc_GRDECL_kw(
                 nx, ny, nz, from_cwrap<rd_kw_type>(zcorn),
-                from_cwrap<rd_kw_type>(coord), from_cwrap<rd_kw_type>(actnum),
-                from_cwrap<rd_kw_type>(mapaxes)));
+                from_cwrap<rd_kw_type>(coord), from_cwrap_opt_kw(actnum),
+                from_cwrap_opt_kw(mapaxes)));
         },
         py::return_value_policy::reference);
     m.def(

--- a/lib/resdata/rd_grid_pybind.cpp
+++ b/lib/resdata/rd_grid_pybind.cpp
@@ -9,20 +9,12 @@
 
 #include <resdata/rd_grid.hpp>
 
+#include <detail/resdata/cwrap_pybind.hpp>
+
 namespace py = pybind11;
 using fmt::format;
 
 namespace {
-template <typename T> T *from_cwrap(py::handle obj) {
-    if (obj.is_none())
-        return nullptr;
-
-    py::int_ address = obj.attr("_BaseCClass__c_pointer");
-    void *pointer = PyLong_AsVoidPtr(address.ptr());
-
-    return reinterpret_cast<T *>(pointer);
-}
-
 PYBIND11_MODULE(_grid, m) {
     m.doc() = "pybind11 bindings between rd_grid.py and rd_grid.cpp";
 

--- a/lib/resdata/rd_kw.cpp
+++ b/lib/resdata/rd_kw.cpp
@@ -1401,15 +1401,6 @@ bool rd_kw_fseek_kw(const char *kw, bool rewind, bool abort_on_error,
     return kw_found;
 }
 
-bool rd_kw_ifseek_kw(const char *kw, fortio_type *fortio, int index) {
-    int i = 0;
-    do {
-        rd_kw_fseek_kw(kw, false, true, fortio);
-        i++;
-    } while (i <= index);
-    return true;
-}
-
 void rd_kw_set_data_ptr(rd_kw_type *rd_kw, void *data) {
     if (!rd_kw->shared_data)
         free(rd_kw->data);

--- a/lib/resdata/rd_kw_pybind.cpp
+++ b/lib/resdata/rd_kw_pybind.cpp
@@ -10,19 +10,11 @@
 #include <resdata/rd_kw_grdecl.hpp>
 #include <resdata/rd_type.hpp>
 
+#include <detail/resdata/cwrap_pybind.hpp>
+
 namespace py = pybind11;
 
 namespace {
-template <typename T> T *from_cwrap(py::handle obj) {
-    if (obj.is_none())
-        return nullptr;
-
-    py::int_ address = obj.attr("_BaseCClass__c_pointer");
-    void *pointer = PyLong_AsVoidPtr(address.ptr());
-
-    return reinterpret_cast<T *>(pointer);
-}
-
 PYBIND11_MODULE(_kw, m) {
     m.doc() = "pybind11 bindings between rd_kw.py and rd_kw.cpp";
 

--- a/lib/resdata/rd_kw_pybind.cpp
+++ b/lib/resdata/rd_kw_pybind.cpp
@@ -24,8 +24,6 @@ PYBIND11_MODULE(_kw, m) {
            py::handle data_type) {
             auto *stream = from_cwrap<FILE>(file);
             auto *rd_data_type = from_cwrap<::rd_data_type>(data_type);
-            if (rd_data_type == nullptr)
-                throw std::invalid_argument("data_type must not be None");
             if (kw.has_value())
                 return reinterpret_cast<std::uintptr_t>(
                     rd_kw_fscanf_alloc_grdecl(stream, kw->c_str(),

--- a/lib/resdata/rd_sum_pybind.cpp
+++ b/lib/resdata/rd_sum_pybind.cpp
@@ -18,18 +18,11 @@
 #include <resdata/rd_sum_vector.hpp>
 #include <resdata/smspec_node.hpp>
 
+#include <detail/resdata/cwrap_pybind.hpp>
+
 namespace py = pybind11;
 
 namespace {
-template <typename T> T *from_cwrap(py::handle obj) {
-    if (obj.is_none())
-        return nullptr;
-
-    py::int_ address = obj.attr("_BaseCClass__c_pointer");
-    void *pointer = PyLong_AsVoidPtr(address.ptr());
-
-    return reinterpret_cast<T *>(pointer);
-}
 
 PYBIND11_MODULE(_rd_sum, m) {
     m.doc() = "pybind11 bindings between rd_sum.py and rd_sum.cpp";

--- a/tests/rd_tests/test_grid.py
+++ b/tests/rd_tests/test_grid.py
@@ -963,3 +963,39 @@ def kws(
 def test_grid_create(specgrid, zcorn, coord, actnum, mapaxes):
     with suppress(ValueError, IndexError):
         Grid.create(specgrid, zcorn, coord, actnum, mapaxes)
+
+
+@pytest.mark.parametrize("bad", [5, None, IntVector(initial_size=1)])
+def test_that_grid_create_with_wrong_type_zcorn_raises_type_error(bad):
+    dims = (2, 2, 2)
+    coord = GridGen.create_coord(dims, (1, 1, 1))
+    with pytest.raises(TypeError, match="Expected ResdataKW"):
+        Grid.create(dims, bad, coord, None)
+
+
+@pytest.mark.parametrize("bad", [5, None, IntVector(initial_size=1)])
+def test_that_grid_create_with_wrong_type_coord_raises_type_error(bad):
+    dims = (2, 2, 2)
+    zcorn = GridGen.create_zcorn(dims, (1, 1, 1), offset=0)
+    with pytest.raises(TypeError, match="Expected ResdataKW"):
+        Grid.create(dims, zcorn, bad, None)
+
+
+@pytest.mark.parametrize("bad", [5, IntVector(initial_size=1)])
+def test_that_grid_create_with_wrong_type_actnum_or_mapaxes_raises_type_error(bad):
+    dims = (2, 2, 2)
+    coord = GridGen.create_coord(dims, (1, 1, 1))
+    zcorn = GridGen.create_zcorn(dims, (1, 1, 1), offset=0)
+    with pytest.raises(TypeError, match="Expected ResdataKW"):
+        Grid.create(dims, zcorn, coord, bad)
+    with pytest.raises(TypeError, match="Expected ResdataKW"):
+        Grid.create(dims, zcorn, coord, None, bad)
+
+
+def test_that_grid_create_accepts_none_actnum_and_mapaxes():
+    dims = (2, 2, 2)
+    coord = GridGen.create_coord(dims, (1, 1, 1))
+    zcorn = GridGen.create_zcorn(dims, (1, 1, 1), offset=0)
+    grid = Grid.create(dims, zcorn, coord, None, None)
+    assert grid is not None
+    assert grid.get_num_active() == 2 * 2 * 2

--- a/tests/rd_tests/test_rd_grid_misc.py
+++ b/tests/rd_tests/test_rd_grid_misc.py
@@ -204,7 +204,7 @@ def test_that_load_column_with_mismatched_kw_size_raises_value_error(
     bad_kw = ResdataKW("BAD", 7, ResDataType.RD_FLOAT)
     column = DoubleVector()
     with pytest.raises(ValueError, match="incommensurable sizes"):
-        _grid._load_column(rectangular_grid, bad_kw, 0, 0, column)
+        rectangular_grid.load_column(bad_kw, 0, 0, column)
 
 
 def test_that_load_column_with_non_numeric_kw_raises_value_error(rectangular_grid):
@@ -212,7 +212,26 @@ def test_that_load_column_with_non_numeric_kw_raises_value_error(rectangular_gri
     char_kw = ResdataKW("CHARKW", size, ResDataType.RD_CHAR)
     column = DoubleVector()
     with pytest.raises(ValueError, match="can not lookup type"):
-        _grid._load_column(rectangular_grid, char_kw, 0, 0, column)
+        rectangular_grid.load_column(char_kw, 0, 0, column)
+
+
+@pytest.mark.parametrize("bad_kw", [5, None, DoubleVector()])
+def test_that_load_column_with_wrong_type_kw_raises_type_error(
+    rectangular_grid, bad_kw
+):
+    column = DoubleVector()
+    with pytest.raises(TypeError, match="Expected ResdataKW"):
+        rectangular_grid.load_column(bad_kw, 0, 0, column)
+
+
+@pytest.mark.parametrize("bad_column", [5, None, ResdataKW("X", 1, ResDataType.RD_INT)])
+def test_that_load_column_with_wrong_type_column_raises_type_error(
+    rectangular_grid, bad_column
+):
+    size = rectangular_grid.get_global_size()
+    kw = ResdataKW("PORO", size, ResDataType.RD_FLOAT)
+    with pytest.raises(TypeError, match="Expected DoubleVector"):
+        rectangular_grid.load_column(kw, 0, 0, bad_column)
 
 
 def test_that_fwrite_grdecl_with_invalid_bool_default_raises_value_error(

--- a/tests/rd_tests/test_rd_sum.py
+++ b/tests/rd_tests/test_rd_sum.py
@@ -85,6 +85,21 @@ def test_dump_csv_line():
     assert os.path.getsize(out_path) > 0
 
 
+@pytest.mark.parametrize("bad_keywords", [5, None, StringList()])
+def test_dump_csv_line_with_wrong_type_keywords_raises_type_error(bad_keywords):
+    case = createSummary(
+        "CASE2",
+        [("FOPT", None, 0, "SM3")],
+    )
+    case.fwrite()
+
+    rd_sum = Summary("CASE2")
+    dtime = datetime.datetime(2010, 6, 1, 0, 0, 0)
+    with copen("dump_bad.csv", "w") as out_handle:
+        with pytest.raises(TypeError, match="Expected SummaryKeyWordVector"):
+            rd_sum.dump_csv_line(dtime, bad_keywords, out_handle)
+
+
 @equinor_test()
 class SummaryTest(ResdataTest):
     def setUp(self):
@@ -1382,6 +1397,21 @@ def test_summary_resample():
 
     assert resampled.alloc_time_vector(False) == time_points
     assert resampled["FOPR"].values.tolist() == pytest.approx([100.0, 150.0, 200.0])
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize("bad_time_points", [5, None, DoubleVector()])
+def test_summary_resample_with_wrong_type_time_points_raises_type_error(
+    bad_time_points,
+):
+    create_summary(
+        summary_keys=("FOPR",),
+        times=(0.0, 5.0, 10.0),
+        values=[[100.0], [150.0], [200.0]],
+    )
+    summary = Summary("TEST")
+    with pytest.raises(TypeError, match="Expected TimeVector"):
+        summary.resample("RESAMPLED", bad_time_points)
 
 
 def test_that_reading_non_existent_summary_raises_oserror(tmp_path):


### PR DESCRIPTION
Adds `TypeError` for calls to methods that would lead to undefined behavior.

In order for this to not be a breaking change, we have to be sure that the previous behavior was not defined, at least not in documentation.

The simplest case is that whenever `from_cwrap<T>(self)` is called, somehow inserting anything other than the instance as self (is that even possible?) would not be supported.

Here are some of the less simple cases:

In the call to _rd_sum._fread_alloc, `data_files` is a local variable, so this is unproblematic. Similarly, the following have also always been unproblematic:
* `_rd_sum._init_pandas_frame`, `keywords`
* `_rd_sum._init_pandas_frame_interp`, `keywords`
* `_rd_sum._init_pandas_frame_interp`, `time_points`
* `_rd_sum._dump_csv_line`, `key_words`
* `_rd_sum._export_csv`, `var_list`
* `_grid._fprintf_grdecl2`, `output_unit`
* `_grid._fprintf_GRID2`, `output_unit`
* `_grid._fprintf_EGRID2`, `output_unit`
* `_grid._compressed_kw_copy`, `kw_copy`
* `_grid._global_kw_copy`, `kw_copy`
* `_kw._fprintf_grdecl`, `file`
* `_grid._fwrite_grdecl`, `file`
* `_grid._fprintf_grdecl2`, `file`
* `_rd_sum._dump_csv_line`, `file`
* `_grid._equal`, `other`

For the following function, parameter combinations the following holds: In the call to the function, giving None or an invalid BaseCClass would result in UB. After this change all UB cases are `TypeError`.

* `_rd_sum._resample`, `time_points`
* `_grid._grdecl_create`, `zcorn`
* `_grid._grdecl_create`, `coord`
* `_grid._fwrite_grdecl`, `kw`
* `_grid._load_column`, `kw`
* `_grid._load_column`, `column`
* `_grid._fprintf_grdecl2`, `kw`
* `_kw._load_grdecl`, `cfile`
* `_kw._load_grdecl`, `kw`


The following would give a different exception if given None, but potentially a UB if a different BaseCClass. We have now introduced a `TypeError` instead.

* `_grid._compressed_kw_copy`, `kw`
* `_grid._global_kw_copy`, `kw`
* `_grid._export_data_as_int`, `kw`
* `_grid._export_data_as_double`, `kw`



For `_grid._grdecl_create, `actnum` and `_grid._grdecl_create, `mapaxes`, the only difference is that these could always be None. However, we have now introduced a `TypeError` if not the correct BaseCClass.


