### PR TITLE
Openfortio swallows all exceptions

### DIFF
--- a/python/resdata/resfile/fortio.py
+++ b/python/resdata/resfile/fortio.py
@@ -19,20 +19,18 @@ structure; mainly to support passing FortIO handles to the underlying cpp
 functions.
 """
 
+from contextlib import contextmanager
+
 from resdata.resfile._fortio import FortIO
 from resdata.util.util import monkey_the_camel
 
 
-class FortIOContextManager:
-    def __init__(self, fortio):
-        self.__fortio = fortio
-
-    def __enter__(self):
-        return self.__fortio
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.__fortio.close()
-        return exc_type is not None
+@contextmanager
+def FortIOContextManager(fortio):
+    try:
+        yield fortio
+    finally:
+        fortio.close()
 
 
 def openFortIO(

--- a/tests/rd_tests/test_fortio.py
+++ b/tests/rd_tests/test_fortio.py
@@ -102,6 +102,12 @@ class FortIOTest(ResdataTest):
 
             self.assertTrue(kw1 == kw2)
 
+    def test_context_propagates_exceptions(self):
+        with TestAreaContext("python/fortio/context-exception"):
+            with pytest.raises(ValueError):
+                with openFortIO("file", mode=FortIO.WRITE_MODE, fmt_file=False) as f:
+                    raise ValueError()
+
     def test_is_fortran_file(self):
         with TestAreaContext("python/fortio/guess"):
             kw1 = ResdataKW("KW", 12345, ResDataType.RD_FLOAT)


### PR DESCRIPTION
**Issue**
Resolves #1186 

**Approach**
Error raised inside the `with openFortIO(...)` block was being swallowed because of the old context manager.

This was rewrote using Python's `contextlib.contextmanager` helper. A test for this behaviour was also introduced.