### PR TITLE
Use pybind for gravimetry bindings

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -351,6 +351,31 @@ install(TARGETS _subsidence LIBRARY DESTINATION ${_subsidence_install_dir})
 set_target_properties(
   _subsidence PROPERTIES LIBRARY_OUTPUT_DIRECTORY
                          ${PROJECT_SOURCE_DIR}/python/resdata/gravimetry)
+# -----------------------------------------------------------------
+# Pybind11 extension module: resdata.gravimetry._grav
+# -----------------------------------------------------------------
+pybind11_add_module(_grav resdata/rd_grav_pybind.cpp resdata/cwrap_pybind.cpp)
+target_link_libraries(_grav PRIVATE resdata fmt::fmt)
+target_include_directories(
+  _grav
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+          ${CMAKE_CURRENT_BINARY_DIR}/include
+          ${CMAKE_CURRENT_SOURCE_DIR}/private-include)
+if(SKBUILD)
+  set(_grav_install_dir "python/resdata/gravimetry")
+  if(APPLE)
+    set_target_properties(_grav PROPERTIES INSTALL_RPATH
+                                           "@loader_path/../.libs")
+  else()
+    set_target_properties(_grav PROPERTIES INSTALL_RPATH "$ORIGIN/../.libs")
+  endif()
+else()
+  set(_grav_install_dir "${CMAKE_INSTALL_LIBDIR}")
+endif()
+install(TARGETS _grav LIBRARY DESTINATION ${_grav_install_dir})
+set_target_properties(
+  _grav PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+                   ${PROJECT_SOURCE_DIR}/python/resdata/gravimetry)
 
 # -----------------------------------------------------------------
 # Pybind11 extension module: resdata.summary._rd_sum

--- a/lib/include/resdata/rd_grav.hpp
+++ b/lib/include/resdata/rd_grav.hpp
@@ -1,41 +1,47 @@
 #ifndef ERT_RD_GRAV_H
 #define ERT_RD_GRAV_H
 
+#include <optional>
+#include <string>
+
 #include <resdata/rd_file.hpp>
 #include <resdata/rd_file_view.hpp>
 #include <resdata/rd_grid.hpp>
 #include <resdata/rd_region.hpp>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 typedef struct rd_grav_struct rd_grav_type;
 typedef struct rd_grav_survey_struct rd_grav_survey_type;
 
 void rd_grav_free(rd_grav_type *rd_grav_config);
+
 rd_grav_type *rd_grav_alloc(rd_grid_type *rd_grid,
                             const rd_file_type *init_file);
+
 rd_grav_survey_type *
-rd_grav_add_survey_FIP(rd_grav_type *grav, const char *name,
+rd_grav_add_survey_FIP(rd_grav_type *grav, const std::string &name,
                        const rd_file_view_type *restart_file);
+
 rd_grav_survey_type *
-rd_grav_add_survey_PORMOD(rd_grav_type *grav, const char *name,
+rd_grav_add_survey_PORMOD(rd_grav_type *grav, const std::string &name,
                           const rd_file_view_type *restart_file);
+
 rd_grav_survey_type *
-rd_grav_add_survey_RPORV(rd_grav_type *grav, const char *name,
+rd_grav_add_survey_RPORV(rd_grav_type *grav, const std::string &name,
                          const rd_file_view_type *restart_file);
+
 rd_grav_survey_type *
-rd_grav_add_survey_RFIP(rd_grav_type *grav, const char *name,
+rd_grav_add_survey_RFIP(rd_grav_type *grav, const std::string &name,
                         const rd_file_view_type *restart_file);
-double rd_grav_eval(const rd_grav_type *grav, const char *base,
-                    const char *monitor, rd_region_type *region, double utm_x,
-                    double utm_y, double depth, int phase_mask);
+
+double rd_grav_eval(const rd_grav_type *grav, const std::string &base,
+                    const std::optional<std::string> &monitor,
+                    rd_region_type *region, double utm_x, double utm_y,
+                    double depth, int phase_mask);
+
 void rd_grav_new_std_density(rd_grav_type *grav, rd_phase_enum phase,
                              double default_density);
+
 void rd_grav_add_std_density(rd_grav_type *grav, rd_phase_enum phase,
                              int pvtnum, double density);
 
-#ifdef __cplusplus
-}
-#endif
 #endif

--- a/lib/resdata/cwrap_pybind.cpp
+++ b/lib/resdata/cwrap_pybind.cpp
@@ -6,6 +6,7 @@
 
 #include <resdata/rd_kw.hpp>
 #include <resdata/rd_grid.hpp>
+#include <resdata/rd_grav.hpp>
 #include <resdata/rd_sum.hpp>
 #include <resdata/rd_file.hpp>
 #include <resdata/well/well_info.hpp>
@@ -277,6 +278,14 @@ py::object WellState() {
     return cls;
 }
 
+py::object ResdataGrav() {
+    static py::object cls;
+    if (!cls) {
+        cls = py::module_::import("resdata.gravimetry").attr("ResdataGrav");
+    }
+    return cls;
+}
+
 template <> well_state_type *from_cwrap<well_state_type>(py::handle obj) {
     if (!py::isinstance(obj, WellState()))
         throw py::type_error("Expected WellState, got " +
@@ -299,4 +308,11 @@ py::object WellSegment() {
         cls = py::module_::import("resdata.well").attr("WellSegment");
     }
     return cls;
+}
+template <> rd_grav_type *from_cwrap<rd_grav_type>(py::handle obj) {
+    if (!py::isinstance(obj, ResdataGrav()))
+        throw py::type_error("Expected ResdataGrav, got " +
+                             static_cast<std::string>(py::repr(obj)));
+
+    return cast_cwrap<rd_grav_type>(obj);
 }

--- a/lib/resdata/rd_grav.cpp
+++ b/lib/resdata/rd_grav.cpp
@@ -7,6 +7,9 @@
 
 #include <ert/util/util.hpp>
 
+#include <stdexcept>
+#include <string>
+
 #include <resdata/rd_kw.hpp>
 #include <resdata/rd_util.hpp>
 #include <resdata/rd_file.hpp>
@@ -117,8 +120,9 @@ static const char *get_den_kw(rd_phase_enum phase, rd_version_enum rd_version) {
             return ECLIPSE100_WATER_DEN_KW;
             break;
         default:
-            util_abort("%s: unrecognized phase id:%d \n", __func__, phase);
-            return NULL;
+            throw std::invalid_argument(
+                std::string(__func__) + ": unrecognized phase id: " +
+                std::to_string(static_cast<int>(phase)));
         }
     } else if ((rd_version == ECLIPSE300) ||
                (rd_version == ECLIPSE300_THERMAL)) {
@@ -133,15 +137,16 @@ static const char *get_den_kw(rd_phase_enum phase, rd_version_enum rd_version) {
             return ECLIPSE300_WATER_DEN_KW;
             break;
         default:
-            util_abort("%s: unrecognized phase id:%d \n", __func__, phase);
-            return NULL;
+            throw std::invalid_argument(
+                std::string(__func__) + ": unrecognized phase id: " +
+                std::to_string(static_cast<int>(phase)));
         }
     } else {
-        util_abort("%s: unrecognized simulator id:%d \n", __func__, rd_version);
-        return NULL;
+        throw std::invalid_argument(
+            std::string(__func__) + ": unrecognized simulator id: " +
+            std::to_string(static_cast<int>(rd_version)));
     }
 }
-
 static void rd_grav_phase_ensure_work(rd_grav_phase_type *grav_phase) {
     if (grav_phase->work == NULL)
         grav_phase->work = (double *)util_calloc(grav_phase->grid_cache->size(),
@@ -187,8 +192,8 @@ static double rd_grav_phase_eval(rd_grav_phase_type *base_phase,
 
         return deltag;
     } else {
-        util_abort("%s comparing different phases ... \n", __func__);
-        return -1;
+        throw std::invalid_argument(std::string(__func__) +
+                                    ": comparing different phases");
     }
 }
 
@@ -343,13 +348,13 @@ static bool rd_grav_survey_add_phases(rd_grav_type *rd_grav,
 }
 
 static rd_grav_survey_type *
-rd_grav_survey_alloc_empty(const rd_grav_type *rd_grav, const char *name,
+rd_grav_survey_alloc_empty(const rd_grav_type *rd_grav, const std::string &name,
                            grav_calc_type calc_type) {
     rd_grav_survey_type *survey = new rd_grav_survey_type();
     UTIL_TYPE_ID_INIT(survey, RD_GRAV_SURVEY_ID);
     survey->grid_cache = rd_grav->grid_cache;
     survey->aquifer_cell = rd_grav->aquifer_cell;
-    survey->name = util_alloc_string_copy(name);
+    survey->name = util_alloc_string_copy(name.c_str());
 
     if (calc_type & GRAV_CALC_USE_PORV)
         survey->porv = (double *)util_calloc(rd_grav->grid_cache->size(),
@@ -389,21 +394,17 @@ static void rd_grav_survey_assert_RPORV(const rd_grav_survey_type *survey,
             if (fabs(log_pormod) > 1) {
                 // Detected as error if the effective pore volume multiplier
                 // is greater than 10 or less than 0.10.
-                fprintf(stderr, "----------------------------------------------"
-                                "-------------------\n");
-                fprintf(stderr, "INIT PORV : %g \n", init_porv);
-                fprintf(stderr, "RPORV     : %g \n", rporv);
-                fprintf(stderr, "The RPORV values extracted from the "
-                                "restart file appear to be \n");
-                fprintf(stderr,
-                        "substantially different from the initial porv value. "
-                        "This might indicate \n");
-                fprintf(stderr, "an inconsistency in the RPORV handling. Try "
-                                "using a different simulator version,\n");
-                fprintf(stderr, "or alternatively the PORMOD approach. \n");
-                fprintf(stderr, "----------------------------------------------"
-                                "-------------------\n");
-                exit(1);
+                throw std::runtime_error(
+                    std::string(__func__) +
+                    ": INIT PORV: " + std::to_string(init_porv) +
+                    ", RPORV: " + std::to_string(rporv) +
+                    ". The RPORV values extracted from the restart file appear "
+                    "to be substantially different from the initial porv "
+                    "value. "
+                    "This might indicate an inconsistency in the RPORV "
+                    "handling. "
+                    "Try using a different simulator version, or alternatively "
+                    "the PORMOD approach.");
             }
         }
         check_nr++;
@@ -454,7 +455,7 @@ static void rd_grav_survey_assert_RPORV(const rd_grav_survey_type *survey,
 static rd_grav_survey_type *
 rd_grav_survey_alloc_RPORV(rd_grav_type *rd_grav,
                            const rd_file_view_type *restart_file,
-                           const char *name) {
+                           const std::string &name) {
     rd_grav_survey_type *survey =
         rd_grav_survey_alloc_empty(rd_grav, name, GRAV_CALC_RPORV);
 
@@ -465,8 +466,9 @@ rd_grav_survey_alloc_RPORV(rd_grav_type *rd_grav,
         for (iactive = 0; iactive < rd_kw_get_size(rporv_kw); iactive++)
             survey->porv[iactive] = rd_kw_iget_as_double(rporv_kw, iactive);
     } else
-        util_abort("%s: restart file did not contain %s keyword??\n", __func__,
-                   RPORV_KW);
+        throw std::runtime_error(std::string(__func__) +
+                                 ": restart file did not contain " + RPORV_KW +
+                                 " keyword");
 
     {
         const rd_file_type *init_file = rd_grav->init_file;
@@ -483,7 +485,7 @@ rd_grav_survey_alloc_RPORV(rd_grav_type *rd_grav,
 static rd_grav_survey_type *
 rd_grav_survey_alloc_PORMOD(rd_grav_type *rd_grav,
                             const rd_file_view_type *restart_file,
-                            const char *name) {
+                            const std::string &name) {
     rd::rd_grid_cache &grid_cache = *(rd_grav->grid_cache);
     rd_grav_survey_type *survey =
         rd_grav_survey_alloc_empty(rd_grav, name, GRAV_CALC_PORMOD);
@@ -519,7 +521,7 @@ rd_grav_survey_alloc_PORMOD(rd_grav_type *rd_grav,
 static rd_grav_survey_type *
 rd_grav_survey_alloc_FIP(rd_grav_type *rd_grav,
                          const rd_file_view_type *restart_file,
-                         const char *name) {
+                         const std::string &name) {
 
     rd_grav_survey_type *survey =
         rd_grav_survey_alloc_empty(rd_grav, name, GRAV_CALC_FIP);
@@ -536,7 +538,7 @@ rd_grav_survey_alloc_FIP(rd_grav_type *rd_grav,
 static rd_grav_survey_type *
 rd_grav_survey_alloc_RFIP(rd_grav_type *rd_grav,
                           const rd_file_view_type *restart_file,
-                          const char *name) {
+                          const std::string &name) {
 
     rd_grav_survey_type *survey =
         rd_grav_survey_alloc_empty(rd_grav, name, GRAV_CALC_RFIP);
@@ -559,7 +561,7 @@ static double rd_grav_survey_eval(const rd_grav_survey_type *base_survey,
          phase_nr++) {
         rd_grav_phase_type *base_phase = base_survey->phase_list[phase_nr];
         if (base_phase->phase & phase_mask) {
-            if (monitor_survey != NULL) {
+            if (monitor_survey != nullptr) {
                 const rd_grav_phase_type *monitor_phase =
                     monitor_survey->phase_list[phase_nr];
                 deltag += rd_grav_phase_eval(base_phase, monitor_phase, region,
@@ -591,24 +593,26 @@ rd_grav_type *rd_grav_alloc(rd_grid_type *rd_grid,
     return rd_grav;
 }
 
-static void rd_grav_add_survey__(rd_grav_type *grav, const char *name,
+static void rd_grav_add_survey__(rd_grav_type *grav, const std::string &name,
                                  rd_grav_survey_type *survey) {
     grav->surveys[name] = survey;
 }
 
 rd_grav_survey_type *
-rd_grav_add_survey_RPORV(rd_grav_type *grav, const char *name,
+rd_grav_add_survey_RPORV(rd_grav_type *grav, const std::string &name,
                          const rd_file_view_type *restart_file) {
     rd_grav_survey_type *survey =
         rd_grav_survey_alloc_RPORV(grav, restart_file, name);
-    if (survey == NULL)
-        return NULL;
+
+    if (survey == nullptr)
+        return nullptr;
+
     rd_grav_add_survey__(grav, name, survey);
     return survey;
 }
 
 rd_grav_survey_type *
-rd_grav_add_survey_FIP(rd_grav_type *grav, const char *name,
+rd_grav_add_survey_FIP(rd_grav_type *grav, const std::string &name,
                        const rd_file_view_type *restart_file) {
     rd_grav_survey_type *survey =
         rd_grav_survey_alloc_FIP(grav, restart_file, name);
@@ -619,7 +623,7 @@ rd_grav_add_survey_FIP(rd_grav_type *grav, const char *name,
 }
 
 rd_grav_survey_type *
-rd_grav_add_survey_RFIP(rd_grav_type *grav, const char *name,
+rd_grav_add_survey_RFIP(rd_grav_type *grav, const std::string &name,
                         const rd_file_view_type *restart_file) {
     rd_grav_survey_type *survey =
         rd_grav_survey_alloc_RFIP(grav, restart_file, name);
@@ -630,7 +634,7 @@ rd_grav_add_survey_RFIP(rd_grav_type *grav, const char *name,
 }
 
 rd_grav_survey_type *
-rd_grav_add_survey_PORMOD(rd_grav_type *grav, const char *name,
+rd_grav_add_survey_PORMOD(rd_grav_type *grav, const std::string &name,
                           const rd_file_view_type *restart_file) {
     rd_grav_survey_type *survey =
         rd_grav_survey_alloc_PORMOD(grav, restart_file, name);
@@ -641,32 +645,29 @@ rd_grav_add_survey_PORMOD(rd_grav_type *grav, const char *name,
 }
 
 static rd_grav_survey_type *rd_grav_get_survey(const rd_grav_type *grav,
-                                               const char *name) {
-    if (name == NULL)
-        return NULL; // Calling scope must determine if this is OK?
-    else {
-        if (grav->surveys.count(name) > 0)
-            return grav->surveys.at(name);
-        else {
-            fprintf(stderr,
-                    "Survey name:%s not registered. Available surveys are: "
-                    "\n\n     ",
-                    name);
+                                               const std::string &name) {
+    if (grav->surveys.count(name) > 0)
+        return grav->surveys.at(name);
 
-            for (const auto &survey_pair : grav->surveys)
-                fprintf(stderr, "%s ", survey_pair.first.c_str());
+    std::string available_surveys;
+    for (const auto &survey_pair : grav->surveys)
+        available_surveys += survey_pair.first + " ";
 
-            fprintf(stderr, "\n\n");
-            exit(1);
-        }
-    }
+    throw std::invalid_argument(
+        "Survey name: " + name +
+        " not registered. Available surveys are: " + available_surveys);
 }
 
-double rd_grav_eval(const rd_grav_type *grav, const char *base,
-                    const char *monitor, rd_region_type *region, double utm_x,
-                    double utm_y, double depth, int phase_mask) {
+double rd_grav_eval(const rd_grav_type *grav, const std::string &base,
+                    const std::optional<std::string> &monitor,
+                    rd_region_type *region, double utm_x, double utm_y,
+                    double depth, int phase_mask) {
     rd_grav_survey_type *base_survey = rd_grav_get_survey(grav, base);
-    rd_grav_survey_type *monitor_survey = rd_grav_get_survey(grav, monitor);
+
+    rd_grav_survey_type *monitor_survey = nullptr;
+    if (monitor.has_value()) {
+        monitor_survey = rd_grav_get_survey(grav, monitor.value());
+    }
 
     return rd_grav_survey_eval(base_survey, monitor_survey, region, utm_x,
                                utm_y, depth, phase_mask);

--- a/lib/resdata/rd_grav_pybind.cpp
+++ b/lib/resdata/rd_grav_pybind.cpp
@@ -1,0 +1,114 @@
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <resdata/rd_file.hpp>
+#include <resdata/rd_file_view.hpp>
+#include <resdata/rd_grid.hpp>
+#include <resdata/rd_region.hpp>
+#include <resdata/rd_grav.hpp>
+
+#include <detail/resdata/cwrap_pybind.hpp>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(_grav, m) {
+    register_exceptions(m);
+    m.doc() = "pybind11 bindings for rd_grav.cpp";
+    m.def("_free", [](py::handle self) {
+        auto *grav = from_cwrap<rd_grav_type>(self);
+        rd_grav_free(grav);
+    });
+
+    m.def("_alloc", [](py::handle grid, py::handle init_file) -> py::object {
+        auto *grid_ptr = from_cwrap<rd_grid_type>(grid);
+        auto *init_file_ptr = from_cwrap<rd_file_type>(init_file);
+
+        auto *grav = rd_grav_alloc(grid_ptr, init_file_ptr);
+
+        if (grav == nullptr) {
+            return py::none();
+        }
+
+        return py::int_(reinterpret_cast<uintptr_t>(grav));
+    });
+
+    m.def("_add_survey_RPORV",
+          [](py::handle self, const std::string &name,
+             py::handle restart_file) -> py::object {
+              auto *grav = from_cwrap<rd_grav_type>(self);
+              auto *restart_file_ptr =
+                  from_cwrap<rd_file_view_type>(restart_file);
+
+              auto *survey =
+                  rd_grav_add_survey_RPORV(grav, name, restart_file_ptr);
+              if (survey == nullptr)
+                  return py::none();
+              return py::int_(reinterpret_cast<uintptr_t>(survey));
+          });
+
+    m.def("_add_survey_PORMOD", [](py::handle self, const std::string &name,
+                                   py::handle restart_file) {
+        auto *grav = from_cwrap<rd_grav_type>(self);
+        auto *restart_file_ptr = from_cwrap<rd_file_view_type>(restart_file);
+        rd_grav_add_survey_PORMOD(grav, name, restart_file_ptr);
+    });
+
+    m.def("_add_survey_FIP",
+          [](py::handle self, const std::string &name,
+             py::handle restart_file) -> py::object {
+              auto *grav = from_cwrap<rd_grav_type>(self);
+              auto *restart_file_ptr =
+                  from_cwrap<rd_file_view_type>(restart_file);
+
+              auto *survey =
+                  rd_grav_add_survey_FIP(grav, name, restart_file_ptr);
+
+              if (survey == nullptr) {
+                  return py::none();
+              }
+
+              return py::int_(reinterpret_cast<uintptr_t>(survey));
+          });
+
+    m.def("_add_survey_RFIP", [](py::handle self, const std::string &name,
+                                 py::handle restart_file) {
+        auto *grav = from_cwrap<rd_grav_type>(self);
+        auto *restart_file_ptr = from_cwrap<rd_file_view_type>(restart_file);
+
+        rd_grav_add_survey_RFIP(grav, name, restart_file_ptr);
+    });
+
+    m.def("_eval",
+          [](py::handle self, const std::string &base,
+             const std::optional<std::string> &monitor, py::handle region,
+             double utm_x, double utm_y, double depth, int phase_mask) {
+              auto *grav = from_cwrap<rd_grav_type>(self);
+
+              rd_region_type *region_ptr = nullptr;
+              if (!region.is_none()) {
+                  region_ptr = from_cwrap<rd_region_type>(region);
+              }
+
+              return rd_grav_eval(grav, base, monitor, region_ptr, utm_x, utm_y,
+                                  depth, phase_mask);
+          });
+
+    m.def("_new_std_density",
+          [](py::handle self, int phase, double default_density) {
+              auto *grav = from_cwrap<rd_grav_type>(self);
+              rd_grav_new_std_density(grav, static_cast<rd_phase_enum>(phase),
+                                      default_density);
+          });
+
+    m.def("_add_std_density",
+          [](py::handle self, int phase, int pvtnum, double density) {
+              auto *grav = from_cwrap<rd_grav_type>(self);
+
+              rd_grav_add_std_density(grav, static_cast<rd_phase_enum>(phase),
+                                      pvtnum, density);
+          });
+}

--- a/lib/resdata/rd_util.cpp
+++ b/lib/resdata/rd_util.cpp
@@ -4,6 +4,8 @@
 #include <cctype>
 #include <fstream>
 #include <system_error>
+#include <stdexcept>
+#include <string>
 
 #include <ert/util/ert_api_config.hpp>
 
@@ -51,9 +53,9 @@ const char *rd_get_phase_name(rd_phase_enum phase) {
         return RD_PHASE_NAME_GAS;
         break;
     default:
-        util_abort("%s: phase enum value:%d not recognized \n", __func__,
-                   phase);
-        return NULL;
+        throw std::invalid_argument(
+            std::string(__func__) + ": phase enum value: " +
+            std::to_string(static_cast<int>(phase)) + " not recognized");
     }
 }
 

--- a/python/resdata/gravimetry/rd_grav.py
+++ b/python/resdata/gravimetry/rd_grav.py
@@ -7,11 +7,10 @@ different surveys. The implementation is a thin wrapper around the
 rd_grav.c implementation in the resdata library.
 """
 
-from typing import Optional
-
 from cwrap import BaseCClass
 
-from resdata import Phase, ResdataPrototype
+import resdata.gravimetry._grav as _grav
+from resdata import Phase
 from resdata.grid import Grid, ResdataRegion
 from resdata.resfile import ResdataFile, ResdataFileView
 from resdata.util.util import monkey_the_camel
@@ -35,29 +34,6 @@ class ResdataGrav(BaseCClass):
     """
 
     TYPE_NAME = "rd_grav"
-    _grav_alloc = ResdataPrototype("void* rd_grav_alloc(rd_grid, rd_file)", bind=False)
-    _free = ResdataPrototype("void rd_grav_free(rd_grav)")
-    _add_survey_RPORV = ResdataPrototype(
-        "void*  rd_grav_add_survey_RPORV(rd_grav, char*, rd_file_view)"
-    )
-    _add_survey_PORMOD = ResdataPrototype(
-        "void*  rd_grav_add_survey_PORMOD(rd_grav, char*, rd_file_view)"
-    )
-    _add_survey_FIP = ResdataPrototype(
-        "void*  rd_grav_add_survey_FIP(rd_grav, char*, rd_file_view)"
-    )
-    _add_survey_RFIP = ResdataPrototype(
-        "void*  rd_grav_add_survey_RFIP(rd_grav, char*, rd_file_view)"
-    )
-    _new_std_density = ResdataPrototype(
-        "void rd_grav_new_std_density(rd_grav, int, double)"
-    )
-    _add_std_density = ResdataPrototype(
-        "void rd_grav_add_std_density(rd_grav, int, int, double)"
-    )
-    _eval = ResdataPrototype(
-        "double rd_grav_eval(rd_grav, char*, char*, rd_region, double, double, double, int)"
-    )
 
     def __init__(self, grid: Grid, init_file: ResdataFile):
         """
@@ -68,7 +44,10 @@ class ResdataGrav(BaseCClass):
         """
         self.init_file = init_file  # Inhibit premature garbage collection of init_file
 
-        c_ptr = self._grav_alloc(grid, init_file)
+        c_ptr = _grav._alloc(grid, init_file)
+        if c_ptr is None:
+            raise ValueError("Unable to construct ResdataGrav")
+
         super().__init__(c_ptr)
 
         self.dispatch = {
@@ -89,21 +68,21 @@ class ResdataGrav(BaseCClass):
         ResdataFile instance with data from one report step. A typical way
         to load the @restart_view argument is:
 
-           import datetime
-           from resdata.resfil import ResdataRestartFile
-           ...
-           ...
-           date = datetime.datetime(year, month, day)
-           rst_file = ResdataFile("CASE.UNRST")
-           restart_view1 = rst_file.restart_view(sim_time=date)
-           restart_view2 = rst_file.restart_view(report_step=67)
+            import datetime
+            from resdata.resfile import ResdataRestartFile
+            ...
+            ...
+            date = datetime.datetime(year, month, day)
+            rst_file = ResdataFile("CASE.UNRST")
+            restart_view1 = rst_file.restart_view(sim_time=date)
+            restart_view2 = rst_file.restart_view(report_step=67)
 
         The pore volume of each cell will be calculated based on the
         RPORV keyword from the restart files. The methods
         add_survey_PORMOD() and add_survey_FIP() are alternatives
         which are based on other keywords.
         """
-        self._add_survey_RPORV(survey_name, restart_view)
+        _grav._add_survey_RPORV(self, survey_name, restart_view)
 
     def add_survey_PORMOD(
         self, survey_name: str, restart_view: ResdataFileView
@@ -115,7 +94,7 @@ class ResdataGrav(BaseCClass):
         the PORV_MOD keyword from the restart file; see
         add_survey_RPORV() for further details.
         """
-        self._add_survey_PORMOD(survey_name, restart_view)
+        _grav._add_survey_PORMOD(self, survey_name, restart_view)
 
     def add_survey_FIP(self, survey_name: str, restart_view: ResdataFileView) -> None:
         """
@@ -130,7 +109,7 @@ class ResdataGrav(BaseCClass):
         the new_std_density() (and possibly also add_std_density())
         method before calling the add_survey_FIP() method.
         """
-        void_ptr = self._add_survey_FIP(survey_name, restart_view)
+        void_ptr = _grav._add_survey_FIP(self, survey_name, restart_view)
         if void_ptr is None:
             raise ValueError("Could not add FIP survey due to missing std_density")
 
@@ -143,7 +122,7 @@ class ResdataGrav(BaseCClass):
         calculated based on the RFIPxxx keyword along with the
         per-cell mass density of the respective phases.
         """
-        self._add_survey_RFIP(survey_name, restart_view)
+        _grav._add_survey_RFIP(self, survey_name, restart_view)
 
     def add_survey(self, name: str, restart_view: ResdataFileView, method: str) -> None:
         method_callable = self.dispatch[method]
@@ -183,8 +162,15 @@ class ResdataGrav(BaseCClass):
         sum of the relevant integer constants 'OIL',
         'GAS' and 'WATER'.
         """
-        return self._eval(
-            base_survey, monitor_survey, region, pos[0], pos[1], pos[2], phase_mask
+        return _grav._eval(
+            self,
+            base_survey,
+            monitor_survey,
+            region,
+            pos[0],
+            pos[1],
+            pos[2],
+            phase_mask,
         )
 
     def new_std_density(self, phase_enum, default_density):
@@ -205,7 +191,7 @@ class ResdataGrav(BaseCClass):
         used before you use the add_survey_FIP() method to add a
         survey based on the FIP keyword.
         """
-        self._new_std_density(phase_enum, default_density)
+        _grav._new_std_density(self, phase_enum, default_density)
 
     def add_std_density(self, phase_enum, pvtnum, density):
         """
@@ -225,10 +211,10 @@ class ResdataGrav(BaseCClass):
         used before you use the add_survey_FIP() method to add a
         survey based on the FIP keyword.
         """
-        self._add_std_density(phase_enum, pvtnum, density)
+        _grav._add_std_density(self, phase_enum, pvtnum, density)
 
     def free(self):
-        self._free()
+        _grav._free(self)
 
 
 monkey_the_camel(ResdataGrav, "addSurvey", ResdataGrav.add_survey)

--- a/tests/rd_tests/test_grav.py
+++ b/tests/rd_tests/test_grav.py
@@ -1,5 +1,6 @@
 import datetime
 
+import pytest
 from resdata import ResDataType
 from resdata.gravimetry import ResdataGrav
 from resdata.grid import GridGenerator
@@ -134,3 +135,111 @@ class ResdataGravTest(ResdataTest):
             grav.add_std_density(1, 0, 0.5)
 
             grav.add_survey_RPORV("rporv", restart_view)
+
+    def test_missing_rporv_keyword_raises(self):
+        kws = [
+            ResdataKW(kw, self.grid.get_global_size(), ResDataType.RD_FLOAT)
+            for kw in [
+                "PORO",
+                "PORV",
+                "SWAT",
+                "OIL_DEN",
+            ]
+        ]
+
+        with TestAreaContext("grav_missing_rporv"):
+            write_kws("TEST", kws)
+            init = ResdataFile("TEST.INIT")
+
+            grav = ResdataGrav(self.grid, init)
+
+            restart_file = ResdataFile("TEST.UNRST")
+            restart_view = restart_file.restart_view(sim_time=datetime.date(2000, 1, 1))
+
+            grav.new_std_density(1, 0.5)
+            grav.add_std_density(1, 0, 0.5)
+
+            with pytest.raises(RuntimeError, match=r"restart file did not contain"):
+                grav.add_survey_RPORV("rporv", restart_view)
+
+    def test_invalid_phase_id_raises_python_exception(self):
+        kws = [
+            ResdataKW(kw, self.grid.get_global_size(), ResDataType.RD_FLOAT)
+            for kw in [
+                "PORO",
+                "PORV",
+                "SWAT",
+                "OIL_DEN",
+                "RPORV",
+            ]
+        ]
+
+        with TestAreaContext("grav_invalid_phase"):
+            write_kws("TEST", kws)
+            init = ResdataFile("TEST.INIT")
+            grav = ResdataGrav(self.grid, init)
+
+            with pytest.raises(
+                ValueError, match=r"phase enum value: 999 not recognized"
+            ):
+                grav.new_std_density(999, 0.5)
+
+    def test_eval_unknown_survey_raises(self):
+        kws = [
+            ResdataKW(kw, self.grid.get_global_size(), ResDataType.RD_FLOAT)
+            for kw in [
+                "PORO",
+                "PORV",
+                "SWAT",
+                "OIL_DEN",
+                "RPORV",
+            ]
+        ]
+
+        with TestAreaContext("grav_unknown_survey"):
+            write_kws("TEST", kws)
+            init = ResdataFile("TEST.INIT")
+
+            grav = ResdataGrav(self.grid, init)
+
+            restart_file = ResdataFile("TEST.UNRST")
+            restart_view = restart_file.restart_view(sim_time=datetime.date(2000, 1, 1))
+
+            grav.new_std_density(1, 0.5)
+            grav.add_std_density(1, 0, 0.5)
+            grav.add_survey_RPORV("rporv", restart_view)
+
+            with pytest.raises(
+                ValueError,
+                match=r"Survey name: does_not_exist not registered",
+            ):
+                grav.eval("does_not_exist", None, (0, 0, 0), phase_mask=1)
+
+    def test_that_rporv_inconsistency_raises(self):
+        size = self.grid.get_global_size()
+        porv = ResdataKW("PORV", size, ResDataType.RD_FLOAT)
+        rporv = ResdataKW("RPORV", size, ResDataType.RD_FLOAT)
+
+        for i in range(size):
+            porv[i] = 1.0
+            rporv[i] = 1000.0
+
+        kws = [porv, rporv]
+
+        with TestAreaContext("grav_bad_rporv"):
+            write_kws("TEST", kws)
+            init = ResdataFile("TEST.INIT")
+
+            grav = ResdataGrav(self.grid, init)
+
+            restart_file = ResdataFile("TEST.UNRST")
+            restart_view = restart_file.restart_view(sim_time=datetime.date(2000, 1, 1))
+
+            grav.new_std_density(1, 0.5)
+            grav.add_std_density(1, 0, 0.5)
+
+            with pytest.raises(
+                RuntimeError,
+                match=r"substantially different from the initial porv value",
+            ):
+                grav.add_survey_RPORV("rporv", restart_view)


### PR DESCRIPTION
Replace ResdataPrototype calls and let gravimetry errors propagate as Python exceptions.

**Issue**
Resolves #1204 

**Approach**
Added a pybind module for the gravimetry bindings and updated ResdataGrav to call this module instead of using ResdataPrototype.

Converted relevant aborting error paths to exceptions so Python callers can handle them normally.
 