### PR TITLE
 Fix null keyword segfault after rd_kw_fread_alloc

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -315,6 +315,7 @@ add_executable(
   tests/test_rd_util.cpp
   tests/test_fortio.cpp
   tests/test_geometry.cpp
+  tests/test_rd_file_kw.cpp
   tests/testsuite.cpp
   tests/test_util.cpp
   tests/test_rd_region.cpp

--- a/lib/resdata/rd_file_kw.cpp
+++ b/lib/resdata/rd_file_kw.cpp
@@ -164,6 +164,11 @@ bool rd_file_kw_equal(const rd_file_kw_type *kw1, const rd_file_kw_type *kw2) {
 }
 
 static void rd_file_kw_assert_kw(const rd_file_kw_type *file_kw) {
+    if (file_kw->kw == NULL)
+        throw std::runtime_error(
+            "rd_file_kw: keyword could not be loaded from file "
+            "(rd_kw_fread_alloc returned NULL)");
+
     if (!rd_type_is_equal(rd_file_kw_get_data_type(file_kw),
                           rd_kw_get_data_type(file_kw->kw)))
         util_abort("%s: type mismatch between header and file.\n", __func__);
@@ -197,10 +202,8 @@ static void rd_file_kw_load_kw(rd_file_kw_type *file_kw, ERT::FortIO &fortio,
     {
         fortio.fseek(file_kw->file_offset, SEEK_SET);
         file_kw->kw = rd_kw_fread_alloc(fortio);
-        if (file_kw->kw != NULL) {
-            rd_file_kw_assert_kw(file_kw);
-            inv_map_add_kw(inv_map, file_kw, file_kw->kw);
-        }
+        rd_file_kw_assert_kw(file_kw);
+        inv_map_add_kw(inv_map, file_kw, file_kw->kw);
     }
 }
 
@@ -273,9 +276,6 @@ bool rd_file_kw_fskip_data(const rd_file_kw_type *file_kw,
 */
 
 void rd_file_kw_inplace_fwrite(rd_file_kw_type *file_kw, ERT::FortIO &fortio) {
-    if (file_kw->kw == NULL)
-        throw std::invalid_argument(
-            "rd_file_kw: cannot write keyword that is not loaded");
     rd_file_kw_assert_kw(file_kw);
     fortio.fseek(file_kw->file_offset, SEEK_SET);
     rd_kw_fskip_header(fortio);

--- a/lib/resdata/rd_file_kw.cpp
+++ b/lib/resdata/rd_file_kw.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
+#include <stdexcept>
 
 #include <ert/util/size_t_vector.hpp>
 #include <ert/util/util.hpp>
@@ -196,8 +197,10 @@ static void rd_file_kw_load_kw(rd_file_kw_type *file_kw, ERT::FortIO &fortio,
     {
         fortio.fseek(file_kw->file_offset, SEEK_SET);
         file_kw->kw = rd_kw_fread_alloc(fortio);
-        rd_file_kw_assert_kw(file_kw);
-        inv_map_add_kw(inv_map, file_kw, file_kw->kw);
+        if (file_kw->kw != NULL) {
+            rd_file_kw_assert_kw(file_kw);
+            inv_map_add_kw(inv_map, file_kw, file_kw->kw);
+        }
     }
 }
 
@@ -270,6 +273,9 @@ bool rd_file_kw_fskip_data(const rd_file_kw_type *file_kw,
 */
 
 void rd_file_kw_inplace_fwrite(rd_file_kw_type *file_kw, ERT::FortIO &fortio) {
+    if (file_kw->kw == NULL)
+        throw std::invalid_argument(
+            "rd_file_kw: cannot write keyword that is not loaded");
     rd_file_kw_assert_kw(file_kw);
     fortio.fseek(file_kw->file_offset, SEEK_SET);
     rd_kw_fskip_header(fortio);

--- a/lib/resdata/tests/rd_file_view.cpp
+++ b/lib/resdata/tests/rd_file_view.cpp
@@ -1,6 +1,5 @@
 #include <cstdlib>
 #include <unistd.h>
-#include <stdexcept>
 
 #include <ert/util/test_util.hpp>
 #include <ert/util/util.hpp>
@@ -96,29 +95,8 @@ void test_create_file_kw() {
     rd_file_kw_free(file_kw2);
 }
 
-void test_unloaded_file_kw_is_rejected() {
-    rd_file_kw_type *file_kw = rd_file_kw_alloc0("TEST_KW", RD_INT, 10, 0);
-
-    rd::util::TestArea ta("reject_unloaded");
-    FILE *fp = util_fopen("dummy", "w");
-    fclose(fp);
-
-    ERT::FortIO fortio("dummy", std::ios_base::in, false, true);
-
-    bool threw = false;
-    try {
-        rd_file_kw_inplace_fwrite(file_kw, fortio);
-    } catch (const std::invalid_argument &) {
-        threw = true;
-    }
-    test_assert_true(threw);
-
-    rd_file_kw_free(file_kw);
-}
-
 int main(int argc, char **argv) {
     util_install_signals();
     test_file_kw_equal();
     test_create_file_kw();
-    test_unloaded_file_kw_is_rejected();
 }

--- a/lib/resdata/tests/rd_file_view.cpp
+++ b/lib/resdata/tests/rd_file_view.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <unistd.h>
+#include <stdexcept>
 
 #include <ert/util/test_util.hpp>
 #include <ert/util/util.hpp>
@@ -9,6 +10,7 @@
 #include <resdata/rd_file.hpp>
 #include <resdata/rd_file_view.hpp>
 #include <resdata/rd_file_kw.hpp>
+#include <resdata/FortIO.hpp>
 
 void test_file_kw_equal() {
     rd_file_kw_type *kw1 = rd_file_kw_alloc0("PRESSURE", RD_FLOAT, 1000, 66);
@@ -94,8 +96,29 @@ void test_create_file_kw() {
     rd_file_kw_free(file_kw2);
 }
 
+void test_unloaded_file_kw_is_rejected() {
+    rd_file_kw_type *file_kw = rd_file_kw_alloc0("TEST_KW", RD_INT, 10, 0);
+
+    rd::util::TestArea ta("reject_unloaded");
+    FILE *fp = util_fopen("dummy", "w");
+    fclose(fp);
+
+    ERT::FortIO fortio("dummy", std::ios_base::in, false, true);
+
+    bool threw = false;
+    try {
+        rd_file_kw_inplace_fwrite(file_kw, fortio);
+    } catch (const std::invalid_argument &) {
+        threw = true;
+    }
+    test_assert_true(threw);
+
+    rd_file_kw_free(file_kw);
+}
+
 int main(int argc, char **argv) {
     util_install_signals();
     test_file_kw_equal();
     test_create_file_kw();
+    test_unloaded_file_kw_is_rejected();
 }

--- a/lib/tests/test_rd_file_kw.cpp
+++ b/lib/tests/test_rd_file_kw.cpp
@@ -16,7 +16,7 @@ TEST_CASE_METHOD(Tmpdir,
     std::unique_ptr<rd_file_kw_type, decltype(&rd_file_kw_free)> file_kw(
         rd_file_kw_alloc0("TEST_KW", RD_INT, 10, 0), &rd_file_kw_free);
 
-    auto filename = (   dirname / "dummy").string();
+    auto filename = (dirname / "dummy").string();
     {
         std::ofstream ofs(filename);
         REQUIRE(ofs);

--- a/lib/tests/test_rd_file_kw.cpp
+++ b/lib/tests/test_rd_file_kw.cpp
@@ -1,0 +1,29 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <fstream>
+#include <ios>
+#include <memory>
+#include <stdexcept>
+
+#include <resdata/FortIO.hpp>
+#include <resdata/rd_file_kw.hpp>
+#include <resdata/rd_util.hpp>
+
+#include "tmpdir.hpp"
+
+TEST_CASE_METHOD(Tmpdir,
+                 "rd_file_kw_inplace_fwrite rejects an unloaded keyword") {
+    std::unique_ptr<rd_file_kw_type, decltype(&rd_file_kw_free)> file_kw(
+        rd_file_kw_alloc0("TEST_KW", RD_INT, 10, 0), &rd_file_kw_free);
+
+    auto filename = (   dirname / "dummy").string();
+    {
+        std::ofstream ofs(filename);
+        REQUIRE(ofs);
+    }
+
+    ERT::FortIO fortio(filename, std::ios_base::in, false, true);
+
+    REQUIRE_THROWS_AS(rd_file_kw_inplace_fwrite(file_kw.get(), fortio),
+                      std::invalid_argument);
+}

--- a/lib/tests/test_rd_file_kw.cpp
+++ b/lib/tests/test_rd_file_kw.cpp
@@ -25,5 +25,5 @@ TEST_CASE_METHOD(Tmpdir,
     ERT::FortIO fortio(filename, std::ios_base::in, false, true);
 
     REQUIRE_THROWS_AS(rd_file_kw_inplace_fwrite(file_kw.get(), fortio),
-                      std::invalid_argument);
+                      std::runtime_error);
 }


### PR DESCRIPTION
rd_file_kw loads keyword data lazily from disk. When rd_kw_fread_alloc fails, file_kw->kw is NULL, but the code still validated and registered the keyword — causing a segfault.

This PR skips that work when load fails, and throws std::invalid_argument if an unloaded keyword is written in place. A regression test covers the write path.
