### PR TITLE
Use PyPI trusted publishing for wheel releases

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -99,6 +99,12 @@ jobs:
 
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
+    environment:
+      name: pypi
+
+    permissions:
+      id-token: write # required for trusted publishing (OIDC)
+
     steps:
       - name: Get wheels
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -110,5 +116,4 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
-          password: ${{ secrets.PYPI_TOKEN_RESDATA }}
           skip-existing: true


### PR DESCRIPTION
Replace the PYPI_TOKEN_RESDATA secret with OIDC-based trusted publishing, removing the need for a long-lived API token.

More info: https://docs.pypi.org/trusted-publishers/using-a-publisher/

**Issue**
None

**Approach**
Following the [guideline in the PyPI docs](https://docs.pypi.org/trusted-publishers/using-a-publisher/). Also configured a `pypi` environment within the repository that can be used for fine-grained control. Some changes must be made to the configuration on the PyPI website. I asked a user that has admin rights to prepare the package settings on pypi.org.