### PR TITLE
Set backward-cpp to use backtrace_symbol on clang

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -18,7 +18,7 @@ class ResdataConan(ConanFile):
     def configure(self):
         if self.options.build_tests:
             self.options["catch2"].with_main = True
-        if self.settings.os == "Macos":
+        if self.settings.compiler == "clang":
             self.options["backward-cpp"].stack_details = "backtrace_symbol"
 
     def generate(self):


### PR DESCRIPTION
This was set for macos, however, when clang is used on linux, the same option has to be set.
