### PR TITLE
Guard negative report_step before indexing in TimeIndex

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -224,6 +224,7 @@ add_executable(
   tests/test_rd_grid_bounds_checking.cpp
   tests/test_rd_sum.cpp
   tests/test_rd_type.cpp
+  tests/test_time_index.cpp
   tests/test_rd_kw.cpp
   tests/test_well_info.cpp
   tests/test_well_keyword_validation.cpp

--- a/lib/private-include/detail/resdata/rd_sum_file_data.hpp
+++ b/lib/private-include/detail/resdata/rd_sum_file_data.hpp
@@ -1,8 +1,10 @@
+#include <algorithm>
 #include <vector>
 #include <memory>
 #include <array>
 #include <limits>
 #include <string>
+#include <stdexcept>
 
 #include <ert/util/vector.hpp>
 
@@ -29,6 +31,8 @@ struct IndexNode {
 class TimeIndex {
 public:
     void add(time_t sim_time, double sim_seconds, int report_step) {
+        if (report_step < 0)
+            throw std::invalid_argument("report step cannot be negative");
         int internal_index = static_cast<int>(this->nodes.size());
         this->nodes.emplace_back(sim_time, sim_seconds, report_step);
 
@@ -44,6 +48,10 @@ public:
     }
 
     bool has_report(int report_step) const {
+
+        if (report_step < 0)
+            return false;
+
         if (report_step >= static_cast<int>(this->report_map.size()))
             return false;
 
@@ -68,10 +76,14 @@ public:
     size_t size() const { return this->nodes.size(); }
 
     std::pair<int, int> &report_range(int report_step) {
+        if (report_step < 0)
+            throw std::invalid_argument("report step cannot be negative");
         return this->report_map[report_step];
     }
 
     const std::pair<int, int> &report_range(int report_step) const {
+        if (report_step < 0)
+            throw std::invalid_argument("report step cannot be negative");
         return this->report_map[report_step];
     }
 

--- a/lib/resdata/rd_sum_file_data.cpp
+++ b/lib/resdata/rd_sum_file_data.cpp
@@ -15,6 +15,15 @@
 
 namespace fs = std::filesystem;
 
+namespace {
+
+void validate_report_step(int report_step) {
+    if (report_step < 0)
+        throw std::invalid_argument("report step cannot be negative");
+}
+
+} // namespace
+
 /*
   This file implements the type rd_sum_data_type. The data structure
   is involved with holding all the actual summary data (the
@@ -288,6 +297,8 @@ void rd_sum_file_data::append_tstep(rd_sum_tstep_type *tstep) {
 
 rd_sum_tstep_type *rd_sum_file_data::add_new_tstep(int report_step,
                                                    double sim_seconds) {
+    validate_report_step(report_step);
+
     int ministep_nr = vector_get_size(data);
     std::unique_ptr<rd_sum_tstep_type, decltype(&rd_sum_tstep_free)> tstep(
         rd_sum_tstep_alloc_new(report_step, ministep_nr, sim_seconds,
@@ -535,6 +546,7 @@ bool rd_sum_file_data::check_file(rd_file_type *rd_file) {
 
 void rd_sum_file_data::add_rd_file(int report_step,
                                    const rd_file_view_type *summary_view) {
+    validate_report_step(report_step);
 
     int num_ministep = rd_file_view_get_num_named_kw(summary_view, PARAMS_KW);
     if (num_ministep > 0) {

--- a/lib/tests/test_rd_sum.cpp
+++ b/lib/tests/test_rd_sum.cpp
@@ -459,6 +459,17 @@ TEST_CASE_METHOD(Tmpdir, "Read summary written by writer") {
     }
 }
 
+TEST_CASE_METHOD(Tmpdir, "rd_sum_add_tstep rejects negative report steps") {
+    const auto case_path = (dirname / "NEGATIVE_REPORT_STEP").string();
+    auto rd_sum = make_summary_writer(case_path, /*fmt_output=*/false,
+                                      /*unified=*/true, ":",
+                                      util_make_date_utc(1, 1, 2010),
+                                      /*time_in_days=*/true, 10, 11, 12);
+
+    REQUIRE_THROWS_AS(rd_sum_add_tstep(rd_sum.get(), -1, 0.0),
+                      std::invalid_argument);
+}
+
 TEST_CASE_METHOD(Tmpdir,
                  "rd_sum_alloc_time_solution finds multiple crossings on a "
                  "non-monotonic series") {

--- a/lib/tests/test_time_index.cpp
+++ b/lib/tests/test_time_index.cpp
@@ -1,0 +1,17 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <utility>
+#include <stdexcept>
+
+#include "detail/resdata/rd_sum_file_data.hpp"
+
+TEST_CASE("TimeIndex rejects negative report steps") {
+    rd::TimeIndex index;
+
+    REQUIRE_THROWS_WITH(
+        index.add(0, 0.0, -1),
+        Catch::Matchers::ContainsSubstring("report step cannot be negative"));
+    REQUIRE(index.size() == 0);
+}


### PR DESCRIPTION
Negative report steps can trigger undefined vector access in TimeIndex;

**Issue**
Resolves #1230 

**Approach**
Raise errors when negative report_step is used both in the input boundary and the internal method. 