### PR TITLE
Reject local grid summary entries without LGR metadata

### DIFF
--- a/lib/resdata/rd_smspec.cpp
+++ b/lib/resdata/rd_smspec.cpp
@@ -893,6 +893,12 @@ static bool rd_smspec_fread_header(rd_smspec_type *rd_smspec,
 
         if (rd_file_has_kw(header.get(),
                            LGRS_KW)) { /* The file has LGR information. */
+            if (!rd_file_has_kw(header.get(), NUMLX_KW) ||
+                !rd_file_has_kw(header.get(), NUMLY_KW) ||
+                !rd_file_has_kw(header.get(), NUMLZ_KW))
+                throw std::invalid_argument(
+                    "SMSPEC header has LGRS keyword but is missing one or "
+                    "more required LGR index keywords (NUMLX, NUMLY, NUMLZ)");
             lgrs = rd_file_iget_named_kw(header.get(), LGRS_KW, 0);
             numlx = rd_file_iget_named_kw(header.get(), NUMLX_KW, 0);
             numly = rd_file_iget_named_kw(header.get(), NUMLY_KW, 0);
@@ -949,6 +955,13 @@ static bool rd_smspec_fread_header(rd_smspec_type *rd_smspec,
                     rd::smspec_node::valid_type(kw.c_str(), well.c_str(), num);
                 if (var_type == RD_SMSPEC_INVALID_VAR) {
                     continue;
+                }
+
+                if (rd_smspec_lgr_var_type(var_type) && !rd_smspec->has_lgr) {
+                    throw std::invalid_argument(
+                        "SMSPEC header contains LGR variable '" + kw +
+                        "' but required LGR metadata keywords are missing "
+                        "(expected LGRS, NUMLX, NUMLY, NUMLZ)");
                 }
 
                 if (rd_smspec_lgr_var_type(var_type)) {

--- a/lib/tests/test_rd_sum.cpp
+++ b/lib/tests/test_rd_sum.cpp
@@ -105,6 +105,71 @@ time_t write_test_summary(const std::string &case_path, const WriteSpec &spec,
     return end_time;
 }
 
+void write_single_string_kw(ERT::FortIO &fortio, const char *name,
+                            const char *value) {
+    auto kw = make_rd_kw(name, 1, RD_CHAR);
+    rd_kw_iset_string8(kw.get(), 0, value);
+    rd_kw_fwrite(kw.get(), fortio);
+}
+
+void write_single_int_kw(ERT::FortIO &fortio, const char *name, int value) {
+    auto kw = make_rd_kw(name, 1, RD_INT);
+    rd_kw_iset_int(kw.get(), 0, value);
+    rd_kw_fwrite(kw.get(), fortio);
+}
+
+void write_malformed_lgr_smspec(const fs::path &path, bool with_lgrs,
+                                bool with_numlx, bool with_numly,
+                                bool with_numlz) {
+    constexpr int n = 1;
+    ERT::FortIO fortio(path.string(), std::ios_base::out, false);
+
+    auto dimens = make_rd_kw(DIMENS_KW, DIMENS_SIZE, RD_INT);
+    rd_kw_scalar_set_int(dimens.get(), 0);
+    rd_kw_iset_int(dimens.get(), DIMENS_SMSPEC_SIZE_INDEX, n);
+    rd_kw_iset_int(dimens.get(), DIMENS_SMSPEC_NX_INDEX, 10);
+    rd_kw_iset_int(dimens.get(), DIMENS_SMSPEC_NY_INDEX, 10);
+    rd_kw_iset_int(dimens.get(), DIMENS_SMSPEC_NZ_INDEX, 10);
+    rd_kw_iset_int(dimens.get(), DIMENS_SMSPEC_RESTART_STEP_INDEX, 0);
+    rd_kw_fwrite(dimens.get(), fortio);
+
+    auto keywords_kw = make_rd_kw(KEYWORDS_KW, n, RD_CHAR);
+    auto wgnames_kw = make_rd_kw(WGNAMES_KW, n, RD_CHAR);
+    auto units_kw = make_rd_kw(UNITS_KW, n, RD_CHAR);
+    auto nums_kw = make_rd_kw(NUMS_KW, n, RD_INT);
+
+    rd_kw_iset_string8(keywords_kw.get(), 0, "LBPR");
+    rd_kw_iset_string8(wgnames_kw.get(), 0, "");
+    rd_kw_iset_string8(units_kw.get(), 0, "BARS");
+    rd_kw_iset_int(nums_kw.get(), 0, 0);
+
+    rd_kw_fwrite(keywords_kw.get(), fortio);
+    rd_kw_fwrite(wgnames_kw.get(), fortio);
+    rd_kw_fwrite(nums_kw.get(), fortio);
+    rd_kw_fwrite(units_kw.get(), fortio);
+
+    auto startdat = make_rd_kw(STARTDAT_KW, 3, RD_INT);
+    rd_kw_iset_int(startdat.get(), STARTDAT_DAY_INDEX, 1);
+    rd_kw_iset_int(startdat.get(), STARTDAT_MONTH_INDEX, 1);
+    rd_kw_iset_int(startdat.get(), STARTDAT_YEAR_INDEX, 2010);
+    rd_kw_fwrite(startdat.get(), fortio);
+
+    if (with_lgrs)
+        write_single_string_kw(fortio, LGRS_KW, "LGR1");
+    if (with_numlx)
+        write_single_int_kw(fortio, NUMLX_KW, 4);
+    if (with_numly)
+        write_single_int_kw(fortio, NUMLY_KW, 5);
+    if (with_numlz)
+        write_single_int_kw(fortio, NUMLZ_KW, 6);
+}
+
+void expect_smspec_load_throws(const fs::path &header_path,
+                               const std::string &msg) {
+    REQUIRE_THROWS_WITH(read_smspec(header_path.string(), ":", false),
+                        ContainsSubstring(msg));
+}
+
 } // namespace
 
 TEST_CASE_METHOD(Tmpdir, "Read summary written by writer") {
@@ -1028,6 +1093,26 @@ TEST_CASE_METHOD(Tmpdir,
 TEST_CASE_METHOD(Tmpdir, "Missing case returns null") {
     auto rd_sum = read_summary((dirname / "DOES_NOT_EXIST").string());
     REQUIRE(rd_sum == nullptr);
+}
+
+TEST_CASE_METHOD(Tmpdir, "Malformed SMSPEC LGR metadata is rejected") {
+    SECTION("LGR variable without LGRS/NUML* is rejected") {
+        const fs::path header_path = dirname / "MISSING_LGR_META.SMSPEC";
+        write_malformed_lgr_smspec(header_path, false, false, false, false);
+
+        expect_smspec_load_throws(header_path,
+                                  "required LGR metadata keywords are missing");
+    }
+
+    SECTION("LGRS without complete NUMLX/NUMLY/NUMLZ is rejected") {
+        const fs::path header_path = dirname / "MISSING_NUMLZ.SMSPEC";
+        write_malformed_lgr_smspec(header_path, true, true, true, false);
+
+        expect_smspec_load_throws(
+            header_path,
+            "SMSPEC header has LGRS keyword but is missing one or more "
+            "required LGR index keywords");
+    }
 }
 
 TEST_CASE_METHOD(Tmpdir, "rd_sum_fwrite writes SMSPEC at rd_case") {


### PR DESCRIPTION
Some SMSPEC headers can contain keywords that resolve to local grid refinement variable types without the required LGR metadata keywords. In that case lgrs/numlx/numly/numlz may be NULL, but the LGR branch still tries to read from them.

Detect incomplete LGR metadata and throw a clear exception instead of dereferencing NULL keyword pointers.

**Issue**
Resolves #1233


**Approach**
_Short description of the approach_
