### PR TITLE
Fix a regression to add_keywords

### DIFF
--- a/lib/resdata/rd_sum_vector_pybind.cpp
+++ b/lib/resdata/rd_sum_vector_pybind.cpp
@@ -38,9 +38,8 @@ PYBIND11_MODULE(_rd_sum_keyword_vector, m) {
         return rd_sum_vector_add_key(from_cwrap<rd_sum_vector_type>(self),
                                      key.c_str());
     });
-    m.def("_add_multiple", [](py::handle self, const std::string &pattern) {
-        rd_sum_vector_add_keys(from_cwrap<rd_sum_vector_type>(self),
-                               pattern.c_str());
+    m.def("_add_multiple", [](py::handle self, const char *pattern) {
+        rd_sum_vector_add_keys(from_cwrap<rd_sum_vector_type>(self), pattern);
     });
     m.def("_get_size", [](py::handle self) {
         return rd_sum_vector_get_size(from_cwrap<rd_sum_vector_type>(self));

--- a/python/resdata/summary/rd_sum_keyword_vector.py
+++ b/python/resdata/summary/rd_sum_keyword_vector.py
@@ -36,7 +36,11 @@ class SummaryKeyWordVector(BaseCClass):
         if not success:
             raise KeyError("Failed to add keyword to vector")
 
-    def add_keywords(self, keyword_pattern):
+    def add_keywords(self, keyword_pattern: str | None):
+        """Adds all keywords from rd_sum matching keyword_pattern.
+
+        If keyword_pattern is None then all keywords in rd_sum are added.
+        """
         _rd_sum_keyword_vector._add_multiple(self, keyword_pattern)
 
     def __repr__(self):

--- a/tests/rd_tests/test_rd_sum.py
+++ b/tests/rd_tests/test_rd_sum.py
@@ -2299,3 +2299,18 @@ def test_unsmry_params_non_float_raises():
 
     with pytest.raises((IOError, ValueError)):
         Summary("TEST")
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_add_keywords_with_none_pattern_matches_all_keywords():
+    case = createSummary(
+        "CASE_NONE_PATTERN",
+        [("FOPT", None, 0, "SM3"), ("WOPT", "OP1", 0, "SM3")],
+    )
+    case.fwrite()
+
+    rd_sum = Summary("CASE_NONE_PATTERN")
+    kw_vector = SummaryKeyWordVector(rd_sum)
+    kw_vector.add_keywords(None)
+
+    assert sorted(kw_vector) == sorted(rd_sum.keys())


### PR DESCRIPTION
In 982b02065b3520c742d0ce24b1e62e7704f1a847 the keyword_pattern in add_keywords was assumed to be not None, however, it turns out that this can be None.