### PR TITLE
Remove obsolete Region global-list parent assertion

### DIFF
--- a/tests/rd_tests/test_region_equinor.py
+++ b/tests/rd_tests/test_region_equinor.py
@@ -87,7 +87,6 @@ class RegionTest(ResdataTest):
         OK = True
 
         global_list = reg.get_global_list()
-        self.assertEqual(global_list.parent(), reg)
 
         for gi in global_list:
             i, j, k = self.grid.get_ijk(global_index=gi)


### PR DESCRIPTION
The return type of `global_list` had been changed to a plain `list[int]` and therefore the `parent` member does not exist. Removed the assertion since it is no longer meaningful.
