### PR TITLE
Avoid some usages of int_vector_type & vector_type

### DIFF
--- a/lib/include/ert/util/parser.hpp
+++ b/lib/include/ert/util/parser.hpp
@@ -1,10 +1,6 @@
-#ifndef ERT_PARSER_H
-#define ERT_PARSER_H
+#pragma once
+#include <cstdio>
 #include <ert/util/stringlist.hpp>
-
-#ifdef __cplusplus
-extern "C" {
-#endif // __cplusplus
 
 typedef struct basic_parser_struct basic_parser_type;
 
@@ -119,8 +115,3 @@ stringlist_type *basic_parser_tokenize_buffer(const basic_parser_type *parser,
 bool basic_parser_fseek_string(const basic_parser_type *parser, FILE *stream,
                                const char *string, bool skip_string,
                                bool case_sensitive);
-#ifdef __cplusplus
-}
-#endif // __cplusplus
-
-#endif

--- a/lib/include/ert/util/parser.hpp
+++ b/lib/include/ert/util/parser.hpp
@@ -1,5 +1,9 @@
 #pragma once
 #include <cstdio>
+
+#include <memory>
+#include <string_view>
+
 #include <ert/util/stringlist.hpp>
 
 typedef struct basic_parser_struct basic_parser_type;
@@ -113,5 +117,11 @@ stringlist_type *basic_parser_tokenize_buffer(const basic_parser_type *parser,
                                               bool strip_quote_marks);
 
 bool basic_parser_fseek_string(const basic_parser_type *parser, FILE *stream,
-                               const char *string, bool skip_string,
+                               const std::string_view string, bool skip_string,
                                bool case_sensitive);
+struct BasicParserDeleter {
+    void operator()(basic_parser_type *parser) const {
+        basic_parser_free(parser);
+    }
+};
+using parser_ptr = std::unique_ptr<basic_parser_type, BasicParserDeleter>;

--- a/lib/include/ert/util/util.hpp
+++ b/lib/include/ert/util/util.hpp
@@ -155,7 +155,6 @@ bool util_is_directory(const char *);
 bool util_is_file(const char *);
 void util_set_datetime_values_utc(time_t, int *, int *, int *, int *, int *,
                                   int *);
-void util_fread_dev_urandom(int, char *);
 void util_abort_test_set_intercept_function(const char *);
 void util_exit(const char *fmt, ...);
 void util_install_signals(void);

--- a/lib/include/ert/util/util.hpp
+++ b/lib/include/ert/util/util.hpp
@@ -109,9 +109,7 @@ void util_make_path(const char *);
 double util_file_difftime(const char *, const char *);
 size_t util_file_size(const char *);
 size_t util_fd_size(int fd);
-void util_strupr(char *);
 bool util_string_equal(const char *s1, const char *s2);
-char *util_alloc_strupr_copy(const char *);
 bool util_copy_file(const char *, const char *);
 bool util_copy_file__(const char *src_file, const char *target_file,
                       size_t buffer_size, void *buffer, bool abort_on_error);
@@ -178,8 +176,6 @@ void util_fwrite(const void *, size_t, size_t, FILE *, const char *);
 int util_fread_int(FILE *);
 void util_fwrite_int(int, FILE *);
 int util_get_current_linenr(FILE *stream);
-bool util_fseek_string(FILE *stream, const char *string, bool skip_string,
-                       bool case_sensitive);
 bool util_files_equal(const char *file1, const char *file2);
 double util_kahan_sum(const double *data, size_t N);
 bool util_double_approx_equal(double d1, double d2);
@@ -264,5 +260,10 @@ extern "C" [[noreturn]] void util_abort__(const char *file,
 
 #ifdef __cplusplus
 }
+#include <string_view>
+bool util_fgetc_while_equal(FILE *stream, std::string_view str,
+                            bool case_sensitive);
+bool util_fseek_string(FILE *stream, std::string_view string, bool skip_string,
+                       bool case_sensitive);
 #endif
 #endif

--- a/lib/include/resdata/layer.hpp
+++ b/lib/include/resdata/layer.hpp
@@ -4,9 +4,6 @@
 #include <tuple>
 #include <vector>
 
-#include <ert/util/int_vector.hpp>
-#include <ert/util/type_macros.hpp>
-
 #include <resdata/rd_grid.hpp>
 
 /*
@@ -41,9 +38,9 @@ int layer_iget_edge_value(const layer_type *layer, int i, int j,
                           edge_dir_enum dir);
 bool layer_cell_on_edge(const layer_type *layer, int i, int j);
 int layer_get_cell_sum(const layer_type *layer);
-bool layer_trace_block_content(layer_type *layer, bool erase, int start_i,
-                               int start_j, int value, int_vector_type *i_list,
-                               int_vector_type *j_list);
+std::vector<std::tuple<int, int>>
+layer_trace_block_content(layer_type *layer, bool erase, int start_i,
+                          int start_j, int value);
 bool layer_cell_contact(const layer_type *layer, int i1, int j1, int i2,
                         int j2);
 void layer_add_interp_barrier(layer_type *layer, int c1, int c2);

--- a/lib/include/resdata/nnc_info.hpp
+++ b/lib/include/resdata/nnc_info.hpp
@@ -1,25 +1,16 @@
-#ifndef ERT_NNC_INFO_H
-#define ERT_NNC_INFO_H
-
-#include <ert/util/type_macros.hpp>
+#pragma once
+#include <cstddef>
+#include <vector>
+#include <memory>
 
 #include <resdata/nnc_vector.hpp>
 
 typedef struct nnc_info_struct nnc_info_type;
 
-#ifdef __cplusplus
-#include <vector>
 const std::vector<int> &
 nnc_info_get_grid_index_list(const nnc_info_type *nnc_info, int lgr_nr);
 const std::vector<int> &
 nnc_info_get_self_grid_index_list(const nnc_info_type *nnc_info);
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-UTIL_IS_INSTANCE_HEADER(nnc_info);
 
 nnc_info_type *nnc_info_alloc(int lgr_nr);
 void nnc_info_free(nnc_info_type *nnc_info);
@@ -34,17 +25,11 @@ nnc_vector_type *nnc_info_get_vector(const nnc_info_type *nnc_info, int lgr_nr);
 nnc_vector_type *nnc_info_get_self_vector(const nnc_info_type *nnc_info);
 
 int nnc_info_get_lgr_nr(const nnc_info_type *nnc_info);
-int nnc_info_get_size(const nnc_info_type *nnc_info);
+size_t nnc_info_get_size(const nnc_info_type *nnc_info);
 int nnc_info_get_total_size(const nnc_info_type *nnc_info);
 bool nnc_info_equal(const nnc_info_type *nnc_info1,
                     const nnc_info_type *nnc_info2);
 nnc_info_type *nnc_info_alloc_copy(const nnc_info_type *src_info);
 bool nnc_info_has_grid_index_list(const nnc_info_type *nnc_info, int lgr_nr);
 
-#ifdef __cplusplus
-}
-#include <memory>
-
 using nnc_info_ptr = std::unique_ptr<nnc_info_type, decltype(&nnc_info_free)>;
-#endif
-#endif

--- a/lib/include/resdata/nnc_vector.hpp
+++ b/lib/include/resdata/nnc_vector.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <vector>
 #include <memory>
 
@@ -10,15 +11,15 @@ nnc_vector_get_grid_index_list(const nnc_vector_type *nnc_vector);
 const std::vector<int> &
 nnc_vector_get_nnc_index_list(const nnc_vector_type *nnc_vector);
 
-int nnc_vector_iget_nnc_index(const nnc_vector_type *nnc_vector, int index);
-int nnc_vector_iget_grid_index(const nnc_vector_type *nnc_vector, int index);
+int nnc_vector_iget_nnc_index(const nnc_vector_type *nnc_vector, size_t index);
+int nnc_vector_iget_grid_index(const nnc_vector_type *nnc_vector, size_t index);
 nnc_vector_type *nnc_vector_alloc(int lgr_nr);
 nnc_vector_type *nnc_vector_alloc_copy(const nnc_vector_type *src_vector);
 void nnc_vector_free(nnc_vector_type *nnc_vector);
 void nnc_vector_add_nnc(nnc_vector_type *nnc_vector, int global_cell_number,
                         int nnc_index);
 int nnc_vector_get_lgr_nr(const nnc_vector_type *nnc_vector);
-int nnc_vector_get_size(const nnc_vector_type *nnc_vector);
+size_t nnc_vector_get_size(const nnc_vector_type *nnc_vector);
 bool nnc_vector_equal(const nnc_vector_type *nnc_vector1,
                       const nnc_vector_type *nnc_vector2);
 

--- a/lib/include/resdata/nnc_vector.hpp
+++ b/lib/include/resdata/nnc_vector.hpp
@@ -1,24 +1,14 @@
-#ifndef ERT_NNC_VECTOR_H
-#define ERT_NNC_VECTOR_H
+#pragma once
 
-#include <ert/util/type_macros.hpp>
+#include <vector>
+#include <memory>
 
 typedef struct nnc_vector_struct nnc_vector_type;
 
-#ifdef __cplusplus
-#include <vector>
-#include <memory>
 const std::vector<int> &
 nnc_vector_get_grid_index_list(const nnc_vector_type *nnc_vector);
 const std::vector<int> &
 nnc_vector_get_nnc_index_list(const nnc_vector_type *nnc_vector);
-#endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-UTIL_IS_INSTANCE_HEADER(nnc_vector);
 
 int nnc_vector_iget_nnc_index(const nnc_vector_type *nnc_vector, int index);
 int nnc_vector_iget_grid_index(const nnc_vector_type *nnc_vector, int index);
@@ -28,18 +18,13 @@ void nnc_vector_free(nnc_vector_type *nnc_vector);
 void nnc_vector_add_nnc(nnc_vector_type *nnc_vector, int global_cell_number,
                         int nnc_index);
 int nnc_vector_get_lgr_nr(const nnc_vector_type *nnc_vector);
-void nnc_vector_free__(void *arg);
 int nnc_vector_get_size(const nnc_vector_type *nnc_vector);
 bool nnc_vector_equal(const nnc_vector_type *nnc_vector1,
                       const nnc_vector_type *nnc_vector2);
 
-#ifdef __cplusplus
-}
 using nnc_vector_ptr =
     std::unique_ptr<nnc_vector_type, decltype(&nnc_vector_free)>;
 
 inline nnc_vector_ptr make_nnc_vector(int lgr_nr) {
     return {nnc_vector_alloc(lgr_nr), &nnc_vector_free};
 }
-#endif
-#endif

--- a/lib/include/resdata/rd_smspec.hpp
+++ b/lib/include/resdata/rd_smspec.hpp
@@ -3,6 +3,7 @@
 #include <ctime>
 
 #include <memory>
+#include <variant>
 #include <vector>
 #include <string>
 
@@ -10,6 +11,25 @@
 #include <resdata/smspec_node.hpp>
 
 typedef struct rd_smspec_struct rd_smspec_type;
+
+namespace rd {
+
+/** A summary which stores elapsed time in a TIME vector. */
+struct TimeParamsIndex {
+    int params_index;
+    int seconds_per_unit;
+};
+
+/** A summary which stores the time of each step as a whole date. */
+struct DateParamsIndex {
+    int day;
+    int month;
+    int year;
+};
+
+using TimeInfo = std::variant<TimeParamsIndex, DateParamsIndex>;
+
+} // namespace rd
 
 const std::vector<float> &
 rd_smspec_get_params_default(const rd_smspec_type *rd_smspec);
@@ -54,10 +74,6 @@ rd_smspec_type *rd_smspec_fread_alloc(const std::string &header_file,
                                       bool include_restart);
 void rd_smspec_free(rd_smspec_type *);
 
-int rd_smspec_get_date_day_index(const rd_smspec_type *smspec);
-int rd_smspec_get_date_month_index(const rd_smspec_type *smspec);
-int rd_smspec_get_date_year_index(const rd_smspec_type *smspec);
-
 int rd_smspec_get_general_var_params_index(const rd_smspec_type *rd_smspec,
                                            const char *lookup_kw);
 bool rd_smspec_has_general_var(const rd_smspec_type *rd_smspec,
@@ -66,8 +82,8 @@ std::vector<std::string>
 rd_smspec_select_matching_general_var_list(const rd_smspec_type *smspec,
                                            const char *pattern);
 
+const rd::TimeInfo &rd_smspec_get_time_info(const rd_smspec_type *smspec);
 int rd_smspec_get_time_seconds(const rd_smspec_type *rd_smspec);
-int rd_smspec_get_time_index(const rd_smspec_type *rd_smspec);
 time_t rd_smspec_get_start_time(const rd_smspec_type *);
 bool rd_smspec_get_formatted(const rd_smspec_type *rd_smspec);
 const char *rd_smspec_get_header_file(const rd_smspec_type *rd_smspec);

--- a/lib/include/resdata/rd_sum_tstep.hpp
+++ b/lib/include/resdata/rd_sum_tstep.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <ctime>
 
+#include <memory>
+
 #include <ert/util/type_macros.hpp>
 
 #include <resdata/FortIO.hpp>
@@ -11,7 +13,6 @@
 typedef struct rd_sum_tstep_struct rd_sum_tstep_type;
 
 void rd_sum_tstep_free(rd_sum_tstep_type *ministep);
-void rd_sum_tstep_free__(void *__ministep);
 rd_sum_tstep_type *rd_sum_tstep_alloc_from_file(int report_step,
                                                 int ministep_nr,
                                                 const rd_kw_type *params_kw,
@@ -46,6 +47,9 @@ void rd_sum_tstep_set_from_key(rd_sum_tstep_type *tstep, const char *gen_key,
 double rd_sum_tstep_get_from_key(const rd_sum_tstep_type *tstep,
                                  const char *gen_key);
 bool rd_sum_tstep_has_key(const rd_sum_tstep_type *tstep, const char *gen_key);
+
+using rd_sum_tstep_ptr =
+    std::unique_ptr<rd_sum_tstep_type, decltype(&rd_sum_tstep_free)>;
 
 UTIL_SAFE_CAST_HEADER(rd_sum_tstep);
 UTIL_SAFE_CAST_HEADER_CONST(rd_sum_tstep);

--- a/lib/include/resdata/well/well_branch_collection.hpp
+++ b/lib/include/resdata/well/well_branch_collection.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <memory>
 
 #include <ert/util/type_macros.hpp>
@@ -11,10 +12,8 @@ well_branch_collection_type *well_branch_collection_alloc();
 void well_branch_collection_free(well_branch_collection_type *branches);
 bool well_branch_collection_has_branch(
     const well_branch_collection_type *branches, int branch_id);
-int well_branch_collection_get_size(
-    const well_branch_collection_type *branches);
-const std::shared_ptr<WellSegment> well_branch_collection_iget_start_segment(
-    const well_branch_collection_type *branches, int index);
+size_t
+well_branch_collection_get_size(const well_branch_collection_type *branches);
 const std::shared_ptr<WellSegment> well_branch_collection_get_start_segment(
     const well_branch_collection_type *branches, int branch_id);
 bool well_branch_collection_add_start_segment(

--- a/lib/private-include/detail/resdata/layer_cxx.hpp
+++ b/lib/private-include/detail/resdata/layer_cxx.hpp
@@ -1,12 +1,7 @@
-#ifndef LAYER_CXX_HPP
-#define LAYER_CXX_HPP
-
+#pragma once
 #include <vector>
 #include <resdata/layer.hpp>
 
 bool layer_trace_block_edge(const layer_type *layer, int i, int j, int value,
                             std::vector<int_point2d_type> &corner_list,
-                            int_vector_type *cell_list,
-                            bool dedup_cells = true);
-
-#endif
+                            std::vector<int> &cell_list);

--- a/lib/private-include/detail/resdata/rd_sum_file_data.hpp
+++ b/lib/private-include/detail/resdata/rd_sum_file_data.hpp
@@ -7,8 +7,6 @@
 #include <string>
 #include <stdexcept>
 
-#include <ert/util/vector.hpp>
-
 #include <resdata/rd_smspec.hpp>
 #include <resdata/rd_sum_tstep.hpp>
 #include <resdata/rd_file.hpp>
@@ -144,11 +142,10 @@ private:
     const rd_smspec_type *rd_smspec;
 
     TimeIndex index;
-    vector_type *data;
+    std::vector<rd_sum_tstep_ptr> data;
 
     std::unique_ptr<rd::unsmry_loader> loader;
 
-    void append_tstep(rd_sum_tstep_type *tstep);
     void build_index();
     void fwrite_report(int report_step, ERT::FortIO &fortio) const;
     bool check_file(rd::File *rd_file);

--- a/lib/private-include/detail/resdata/rd_unsmry_loader.hpp
+++ b/lib/private-include/detail/resdata/rd_unsmry_loader.hpp
@@ -28,8 +28,7 @@ public:
 
 private:
     int size; //Number of entries in the smspec index
-    int time_index;
-    int time_seconds;
+    rd::TimeInfo time_info;
     time_t sim_start;
     int m_length; //Number of PARAMS in the UNSMRY file
 

--- a/lib/resdata/fault_block.cpp
+++ b/lib/resdata/fault_block.cpp
@@ -92,12 +92,11 @@ std::vector<std::tuple<double, double, int>> FaultBlock::trace_edge() const {
         return edge;
 
     std::vector<int_point2d_type> corner_list;
-    auto cell_list = make_int_vector(0, 0);
+    std::vector<int> cell_list;
     const auto &[start_i, start_j] = index_list.at(0);
 
     layer_trace_block_edge(fault_block_layer_get_layer(parent_layer), start_i,
-                           start_j, block_id, corner_list, cell_list.get(),
-                           /*dedup_cells=*/false);
+                           start_j, block_id, corner_list, cell_list);
 
     edge.reserve(corner_list.size());
     for (std::size_t idx = 0; idx < corner_list.size(); idx++) {
@@ -105,8 +104,7 @@ std::vector<std::tuple<double, double, int>> FaultBlock::trace_edge() const {
         double x, y, z;
 
         rd_grid_get_corner_xyz(grid, p.i, p.j, k, &x, &y, &z);
-        edge.emplace_back(
-            x, y, int_vector_iget(cell_list.get(), static_cast<int>(idx)));
+        edge.emplace_back(x, y, cell_list.at(idx));
     }
     return edge;
 }

--- a/lib/resdata/fault_block_layer.cpp
+++ b/lib/resdata/fault_block_layer.cpp
@@ -83,22 +83,18 @@ fault_block_layer_add_block(fault_block_layer_type *layer, int block_id) {
 
 void fault_block_layer_scan_layer(fault_block_layer_type *fault_layer,
                                   layer_type *layer) {
-    auto i_list = make_int_vector(0, 0);
-    auto j_list = make_int_vector(0, 0);
-
     for (int j = 0; j < layer_get_ny(layer); j++) {
         for (int i = 0; i < layer_get_nx(layer); i++) {
             int cell_value = layer_iget_cell_value(layer, i, j);
             if (cell_value != 0) {
-                layer_trace_block_content(layer, true, i, j, cell_value,
-                                          i_list.get(), j_list.get());
+                auto indices =
+                    layer_trace_block_content(layer, true, i, j, cell_value);
                 {
                     int block_id = fault_block_layer_get_next_id(fault_layer);
                     auto fault_block =
                         fault_block_layer_add_block(fault_layer, block_id);
-                    for (int c = 0; c < int_vector_size(i_list.get()); c++)
-                        fault_block->add_cell(int_vector_iget(i_list.get(), c),
-                                              int_vector_iget(j_list.get(), c));
+                    for (const auto &[i, j] : indices)
+                        fault_block->add_cell(i, j);
                 }
             }
         }

--- a/lib/resdata/layer.cpp
+++ b/lib/resdata/layer.cpp
@@ -229,7 +229,7 @@ static void layer_trace_block_edge__(const layer_type *layer,
                                      int_point2d_type start_point, int i, int j,
                                      int value, edge_dir_enum dir,
                                      std::vector<int_point2d_type> &corner_list,
-                                     int_vector_type *cell_list) {
+                                     std::vector<int> &cell_list) {
     int_point2d_type current_point;
     int_point2d_type next_point;
     current_point.i = i;
@@ -250,7 +250,7 @@ static void layer_trace_block_edge__(const layer_type *layer,
     corner_list.push_back(current_point);
     {
         int cell_index = i + j * layer->nx;
-        int_vector_append(cell_list, cell_index);
+        cell_list.push_back(cell_index);
     }
 
     if (!point_equal(&start_point, &next_point)) {
@@ -340,7 +340,7 @@ static bool layer_find_edge(const layer_type *layer, int *i, int *j,
 bool layer_trace_block_edge(const layer_type *layer, int start_i, int start_j,
                             int value,
                             std::vector<int_point2d_type> &corner_list,
-                            int_vector_type *cell_list, bool dedup_cells) {
+                            std::vector<int> &cell_list) {
     const Cell &cell = layer->interior_cell(start_i, start_j);
     if (cell.value == value) {
         int i = start_i;
@@ -354,7 +354,7 @@ bool layer_trace_block_edge(const layer_type *layer, int start_i, int start_j,
             start_corner.i = i;
             start_corner.j = j;
             corner_list.clear();
-            int_vector_reset(cell_list);
+            cell_list.clear();
 
             if (next_cell.edges[BOTTOM_EDGE] == value) {
                 point_shift(&start_corner, 0, 0);
@@ -374,9 +374,6 @@ bool layer_trace_block_edge(const layer_type *layer, int start_i, int start_j,
                                          LEFT_EDGE, corner_list, cell_list);
             } else
                 throw std::logic_error("Internal error");
-
-            if (dedup_cells)
-                int_vector_select_unique(cell_list);
             return true;
         }
     }

--- a/lib/resdata/layer.cpp
+++ b/lib/resdata/layer.cpp
@@ -4,12 +4,11 @@
 #include <memory>
 #include <stdexcept>
 #include <tuple>
+#include <utility>
 #include <vector>
 #include <algorithm>
 #include <array>
 #include <fmt/format.h>
-
-#include <ert/util/int_vector.hpp>
 
 #include <resdata/rd_grid.hpp>
 #include <resdata/layer.hpp>
@@ -386,17 +385,14 @@ class BlockTracer {
     bool erase;
     int value;
     std::vector<bool> visited;
-    int_vector_type *i_list;
-    int_vector_type *j_list;
 
 public:
-    BlockTracer(layer_type *layer, bool erase, int value,
-                int_vector_type *i_list, int_vector_type *j_list)
+    std::vector<std::tuple<int, int>> indices;
+    BlockTracer(layer_type *layer, bool erase, int value)
         : layer(layer), erase(erase), value(value),
           visited((static_cast<size_t>(layer->nx) + 1) *
                       (static_cast<size_t>(layer->ny) + 1),
-                  false),
-          i_list(i_list), j_list(j_list) {}
+                  false) {}
 
     void operator()(int i, int j) {
         int g = layer->interior_index(i, j);
@@ -407,8 +403,7 @@ public:
         if (erase)
             layer_iset_cell_value(layer, i, j, 0);
 
-        int_vector_append(i_list, i);
-        int_vector_append(j_list, j);
+        indices.emplace_back(i, j);
 
         if (i > 0)
             (*this)(i - 1, j);
@@ -424,25 +419,20 @@ public:
     }
 };
 
-bool layer_trace_block_content(layer_type *layer, bool erase, int start_i,
-                               int start_j, int value, int_vector_type *i_list,
-                               int_vector_type *j_list) {
-    bool start_tracing = false;
+std::vector<std::tuple<int, int>>
+layer_trace_block_content(layer_type *layer, bool erase, int start_i,
+                          int start_j, int value) {
     const Cell &cell = layer->interior_cell(start_i, start_j);
 
-    if ((value == 0) && (cell.value != 0))
-        start_tracing = true;
-    else if ((cell.value == value) && (cell.value != 0))
-        start_tracing = true;
+    bool start_tracing = ((value == 0) && (cell.value != 0)) ||
+                         ((cell.value == value) && (cell.value != 0));
+    if (!start_tracing)
+        return {};
 
-    if (start_tracing) {
-        value = cell.value;
-        int_vector_reset(i_list);
-        int_vector_reset(j_list);
-        BlockTracer{layer, erase, value, i_list, j_list}(start_i, start_j);
-        return true;
-    } else
-        return false;
+    value = cell.value;
+    BlockTracer bt{layer, erase, value};
+    bt(start_i, start_j);
+    return std::move(bt.indices);
 }
 
 int layer_replace_cell_values(layer_type *layer, int old_value, int new_value) {

--- a/lib/resdata/nnc_info.cpp
+++ b/lib/resdata/nnc_info.cpp
@@ -1,71 +1,49 @@
 #include <cstdlib>
 #include <cstdio>
 
-#include <vector>
+#include <memory>
 #include <stdexcept>
 #include <string>
-
-#include <ert/util/util.hpp>
-#include <ert/util/vector.hpp>
-#include <ert/util/type_macros.hpp>
-
-#include <resdata/nnc_info.hpp>
-#include <resdata/nnc_vector.hpp>
-#include <resdata/rd_kw_magic.hpp>
-
+#include <utility>
 #include <vector>
 #include <algorithm>
 
-template <class T>
-void vector_util_fprintf(const std::vector<T> &vec, FILE *stream,
-                         const char *name, const char *fmt) {
-    size_t i;
-    if (name != NULL)
-        fprintf(stream, "%s = [", name);
-    else
-        fprintf(stream, "[");
-
-    for (i = 0; i < vec.size(); i++) {
-        fprintf(stream, fmt, vec[i]);
-        if (i < (vec.size() - 1))
-            fprintf(stream, ", ");
-    }
-
-    fprintf(stream, "]\n");
-}
-
-#define NNC_INFO_TYPE_ID 675415078
+#include <resdata/nnc_info.hpp>
+#include <resdata/nnc_vector.hpp>
 
 struct nnc_info_struct {
-    UTIL_TYPE_ID_DECLARATION;
-    vector_type *lgr_list; /*List of nnc_vectors for LGRs*/
-    int_vector_type *
+    std::vector<nnc_vector_ptr> lgr_list; /*List of nnc_vectors for LGRs*/
+    std::vector<int>
         lgr_index_map; /* A vector that maps LGR-nr to index into the LGR_list.*/
     int lgr_nr; /* The lgr_nr of the cell holding this nnc_info structure. */
 };
 
 static void nnc_info_add_vector(nnc_info_type *nnc_info,
-                                nnc_vector_type *nnc_vector);
-UTIL_IS_INSTANCE_FUNCTION(nnc_info, NNC_INFO_TYPE_ID)
+                                nnc_vector_ptr &&nnc_vector) {
+    int lgr_nr = nnc_vector_get_lgr_nr(nnc_vector.get());
+    if (lgr_nr < 0)
+        throw std::logic_error("lgr_nr was negative");
+    nnc_info->lgr_list.push_back(std::move(nnc_vector));
+    size_t lgr_index = static_cast<size_t>(lgr_nr);
+    if (lgr_index >= nnc_info->lgr_index_map.size())
+        nnc_info->lgr_index_map.resize(lgr_index + 1, -1);
+    nnc_info->lgr_index_map.at(lgr_index) =
+        static_cast<int>(nnc_info->lgr_list.size()) - 1;
+}
 
 nnc_info_type *nnc_info_alloc(int lgr_nr) {
-    nnc_info_type *nnc_info = (nnc_info_type *)util_malloc(sizeof *nnc_info);
-    UTIL_TYPE_ID_INIT(nnc_info, NNC_INFO_TYPE_ID);
-    nnc_info->lgr_list = vector_alloc_new();
-    nnc_info->lgr_index_map = int_vector_alloc(0, -1);
+    auto nnc_info = std::make_unique<nnc_info_type>();
     nnc_info->lgr_nr = lgr_nr;
-    return nnc_info;
+    return nnc_info.release();
 }
 
 nnc_info_type *nnc_info_alloc_copy(const nnc_info_type *src_info) {
     nnc_info_type *copy_info = nnc_info_alloc(src_info->lgr_nr);
-    int ivec;
 
-    for (ivec = 0; ivec < vector_get_size(src_info->lgr_list); ivec++) {
-        nnc_vector_type *copy_vector =
-            nnc_vector_alloc_copy((const nnc_vector_type *)vector_iget_const(
-                src_info->lgr_list, ivec));
-        nnc_info_add_vector(copy_info, copy_vector);
+    for (const auto &vec : src_info->lgr_list) {
+        nnc_vector_ptr copy_vector{nnc_vector_alloc_copy(vec.get()),
+                                   nnc_vector_free};
+        nnc_info_add_vector(copy_info, std::move(copy_vector));
     }
 
     return copy_info;
@@ -83,29 +61,28 @@ bool nnc_info_equal(const nnc_info_type *nnc_info1,
         if (nnc_info1->lgr_nr != nnc_info2->lgr_nr)
             return false;
 
-        if ((int_vector_size(nnc_info1->lgr_index_map) > 0) &&
-            (int_vector_size(nnc_info2->lgr_index_map) > 0)) {
-            int max_lgr_nr =
-                std::max(int_vector_size(nnc_info1->lgr_index_map),
-                         int_vector_size(nnc_info2->lgr_index_map));
-            int lgr_nr = 0;
+        if ((nnc_info1->lgr_index_map.size() > 0) &&
+            (nnc_info2->lgr_index_map.size() > 0)) {
+            size_t max_lgr_nr = std::max(nnc_info1->lgr_index_map.size(),
+                                         nnc_info2->lgr_index_map.size());
+            size_t lgr_nr = 0;
 
             while (true) {
-                nnc_vector_type *vector1 =
-                    nnc_info_get_vector(nnc_info1, lgr_nr);
-                nnc_vector_type *vector2 =
-                    nnc_info_get_vector(nnc_info2, lgr_nr);
+                const nnc_vector_type *vector1 =
+                    nnc_info_get_vector(nnc_info1, static_cast<int>(lgr_nr));
+                const nnc_vector_type *vector2 =
+                    nnc_info_get_vector(nnc_info2, static_cast<int>(lgr_nr));
 
                 if (!nnc_vector_equal(vector1, vector2))
                     return false;
 
                 lgr_nr++;
-                if (lgr_nr > max_lgr_nr)
+                if (lgr_nr >= max_lgr_nr)
                     return true;
             }
         } else {
-            if (int_vector_size(nnc_info1->lgr_index_map) ==
-                int_vector_size(nnc_info2->lgr_index_map))
+            if (nnc_info1->lgr_index_map.size() ==
+                nnc_info2->lgr_index_map.size())
                 return true;
             else
                 return false;
@@ -113,46 +90,34 @@ bool nnc_info_equal(const nnc_info_type *nnc_info1,
     }
 }
 
-void nnc_info_free(nnc_info_type *nnc_info) {
-    vector_free(nnc_info->lgr_list);
-    int_vector_free(nnc_info->lgr_index_map);
-    free(nnc_info);
-}
+void nnc_info_free(nnc_info_type *nnc_info) { delete nnc_info; }
 
 nnc_vector_type *nnc_info_get_vector(const nnc_info_type *nnc_info,
                                      int lgr_nr) {
-    int lgr_index = int_vector_safe_iget(nnc_info->lgr_index_map, lgr_nr);
+    if (lgr_nr < 0 ||
+        static_cast<size_t>(lgr_nr) >= nnc_info->lgr_index_map.size())
+        return NULL;
+
+    int lgr_index = nnc_info->lgr_index_map[lgr_nr];
     if (-1 == lgr_index)
         return NULL;
     else
-        return (nnc_vector_type *)vector_iget(nnc_info->lgr_list, lgr_index);
+        return nnc_info->lgr_list[lgr_index].get();
 }
 
 nnc_vector_type *nnc_info_iget_vector(const nnc_info_type *nnc_info,
                                       int lgr_index) {
-    return (nnc_vector_type *)vector_iget(nnc_info->lgr_list, lgr_index);
+    return nnc_info->lgr_list.at(lgr_index).get();
 }
 
 nnc_vector_type *nnc_info_get_self_vector(const nnc_info_type *nnc_info) {
     return nnc_info_get_vector(nnc_info, nnc_info->lgr_nr);
 }
 
-static void nnc_info_add_vector(nnc_info_type *nnc_info,
-                                nnc_vector_type *nnc_vector) {
-    vector_append_owned_ref(nnc_info->lgr_list, nnc_vector, nnc_vector_free__);
-    if (nnc_vector_get_lgr_nr(nnc_vector) >=
-        int_vector_size(nnc_info->lgr_index_map))
-        int_vector_resize(nnc_info->lgr_index_map,
-                          nnc_vector_get_lgr_nr(nnc_vector) + 1, -1);
-    int_vector_iset(nnc_info->lgr_index_map, nnc_vector_get_lgr_nr(nnc_vector),
-                    vector_get_size(nnc_info->lgr_list) - 1);
-}
-
 static void nnc_info_assert_vector(nnc_info_type *nnc_info, int lgr_nr) {
     nnc_vector_type *nnc_vector = nnc_info_get_vector(nnc_info, lgr_nr);
     if (!nnc_vector) {
-        nnc_vector = nnc_vector_alloc(lgr_nr);
-        nnc_info_add_vector(nnc_info, nnc_vector);
+        nnc_info_add_vector(nnc_info, make_nnc_vector(lgr_nr));
     }
 }
 
@@ -166,7 +131,7 @@ void nnc_info_add_nnc(nnc_info_type *nnc_info, int lgr_nr,
 }
 
 bool nnc_info_has_grid_index_list(const nnc_info_type *nnc_info, int lgr_nr) {
-    return (nnc_info_get_vector(nnc_info, lgr_nr) != NULL);
+    return nnc_info_get_vector(nnc_info, lgr_nr);
 }
 
 const std::vector<int> &
@@ -186,17 +151,14 @@ int nnc_info_get_lgr_nr(const nnc_info_type *nnc_info) {
     return nnc_info->lgr_nr;
 }
 
-int nnc_info_get_size(const nnc_info_type *nnc_info) {
-    return vector_get_size(nnc_info->lgr_list);
+size_t nnc_info_get_size(const nnc_info_type *nnc_info) {
+    return nnc_info->lgr_list.size();
 }
 
 int nnc_info_get_total_size(const nnc_info_type *nnc_info) {
     int num_nnc = 0;
-    int ivec;
-    for (ivec = 0; ivec < vector_get_size(nnc_info->lgr_list); ivec++) {
-        const nnc_vector_type *nnc_vector =
-            (const nnc_vector_type *)vector_iget(nnc_info->lgr_list, ivec);
-        num_nnc += nnc_vector_get_size(nnc_vector);
+    for (const auto &nnc_vector : nnc_info->lgr_list) {
+        num_nnc += nnc_vector_get_size(nnc_vector.get());
     }
     return num_nnc;
 }

--- a/lib/resdata/nnc_vector.cpp
+++ b/lib/resdata/nnc_vector.cpp
@@ -69,7 +69,7 @@ nnc_vector_get_nnc_index_list(const nnc_vector_type *nnc_vector) {
     return nnc_vector->nnc_index_list;
 }
 
-int nnc_vector_get_size(const nnc_vector_type *nnc_vector) {
+size_t nnc_vector_get_size(const nnc_vector_type *nnc_vector) {
     return nnc_vector->grid_index_list.size();
 }
 
@@ -77,10 +77,11 @@ int nnc_vector_get_lgr_nr(const nnc_vector_type *nnc_vector) {
     return nnc_vector->lgr_nr;
 }
 
-int nnc_vector_iget_nnc_index(const nnc_vector_type *nnc_vector, int index) {
+int nnc_vector_iget_nnc_index(const nnc_vector_type *nnc_vector, size_t index) {
     return nnc_vector->nnc_index_list[index];
 }
 
-int nnc_vector_iget_grid_index(const nnc_vector_type *nnc_vector, int index) {
+int nnc_vector_iget_grid_index(const nnc_vector_type *nnc_vector,
+                               size_t index) {
     return nnc_vector->grid_index_list[index];
 }

--- a/lib/resdata/nnc_vector.cpp
+++ b/lib/resdata/nnc_vector.cpp
@@ -5,32 +5,23 @@
 
 #include <ert/util/util.hpp>
 #include <ert/util/vector.hpp>
-#include <ert/util/type_macros.hpp>
 
 #include <resdata/nnc_vector.hpp>
 
-#define NNC_VECTOR_TYPE_ID 875615078
-
 struct nnc_vector_struct {
-    UTIL_TYPE_ID_DECLARATION;
     int lgr_nr;
     std::vector<int> grid_index_list;
     std::vector<int> nnc_index_list;
 };
 
-UTIL_IS_INSTANCE_FUNCTION(nnc_vector, NNC_VECTOR_TYPE_ID)
-static UTIL_SAFE_CAST_FUNCTION(nnc_vector, NNC_VECTOR_TYPE_ID)
-
-    nnc_vector_type *nnc_vector_alloc(int lgr_nr) {
+nnc_vector_type *nnc_vector_alloc(int lgr_nr) {
     nnc_vector_type *nnc_vector = new nnc_vector_type();
-    UTIL_TYPE_ID_INIT(nnc_vector, NNC_VECTOR_TYPE_ID);
     nnc_vector->lgr_nr = lgr_nr;
     return nnc_vector;
 }
 
 nnc_vector_type *nnc_vector_alloc_copy(const nnc_vector_type *src_vector) {
     nnc_vector_type *copy_vector = new nnc_vector_type();
-    UTIL_TYPE_ID_INIT(copy_vector, NNC_VECTOR_TYPE_ID);
 
     copy_vector->lgr_nr = src_vector->lgr_nr;
     copy_vector->grid_index_list = src_vector->grid_index_list;
@@ -61,11 +52,6 @@ bool nnc_vector_equal(const nnc_vector_type *nnc_vector1,
 }
 
 void nnc_vector_free(nnc_vector_type *nnc_vector) { delete nnc_vector; }
-
-void nnc_vector_free__(void *arg) {
-    nnc_vector_type *nnc_vector = nnc_vector_safe_cast(arg);
-    nnc_vector_free(nnc_vector);
-}
 
 void nnc_vector_add_nnc(nnc_vector_type *nnc_vector, int global_cell_number,
                         int nnc_index) {

--- a/lib/resdata/rd_grid.cpp
+++ b/lib/resdata/rd_grid.cpp
@@ -5102,7 +5102,7 @@ static void rd_grid_fwrite_self_nnc(const rd_grid_type *grid,
                 nnc_info_get_self_vector(nnc_info.get());
             if (!nnc_vector)
                 continue;
-            for (int i = 0; i < nnc_vector_get_size(nnc_vector); i++) {
+            for (size_t i = 0; i < nnc_vector_get_size(nnc_vector); i++) {
                 int nnc_index = nnc_vector_iget_nnc_index(nnc_vector, i);
                 if (nnc_index < 0)
                     throw std::domain_error(

--- a/lib/resdata/rd_smspec.cpp
+++ b/lib/resdata/rd_smspec.cpp
@@ -1,20 +1,21 @@
 #include <cstring>
-#include <cmath>
 #include <ctime>
-#include <cerrno>
 
+#include <ios>
 #include <string>
+#include <system_error>
+#include <utility>
+#include <variant>
 #include <vector>
 #include <map>
 #include <algorithm>
 #include <memory>
 #include <stdexcept>
 #include <filesystem>
+#include <fmt/format.h>
 
 #include <ert/util/util.hpp>
-#include "detail/util/path.hpp"
-
-#include <fmt/format.h>
+#include <ert/util/type_macros.hpp>
 
 #include <resdata/rd_smspec.hpp>
 #include <resdata/rd_file.hpp>
@@ -22,12 +23,8 @@
 #include <resdata/rd_kw.hpp>
 #include <resdata/rd_util.hpp>
 #include <resdata/smspec_node.hpp>
-#include <resdata/rd_endian_flip.hpp>
 #include <resdata/rd_type.hpp>
-
-#ifdef HAVE_FNMATCH
-#include <fnmatch.h>
-#endif
+#include <resdata/FortIO.hpp>
 
 namespace fs = std::filesystem;
 
@@ -114,7 +111,6 @@ struct rd_smspec_struct {
     std::map<int, int> inv_index_map;
     int params_size;
 
-    int time_seconds;
     int grid_dims[3]; /* Grid dimensions - in DIMENS[1,2,3] */
     int num_regions;
     int Nwells, param_offset;
@@ -128,10 +124,7 @@ struct rd_smspec_struct {
         formatted; /* Has this summary instance been loaded from a formatted (i.e. FSMSPEC file) or unformatted (i.e. SMSPEC) file. */
     time_t sim_start_time; /* When did the simulation start - worldtime. */
 
-    int time_index; /* The fields time_index, day_index, month_index and year_index */
-    int day_index; /* are used by the rd_sum_data object to locate per. timestep */
-    int month_index; /* time information. */
-    int year_index;
+    rd::TimeInfo time_info;
     bool has_lgr;
     std::vector<float> params_default;
 
@@ -244,11 +237,6 @@ static rd_smspec_ptr rd_smspec_alloc_empty(bool write_mode,
     rd_smspec->key_join_string = key_join_string;
     rd_smspec->header_file = "";
 
-    rd_smspec->time_index = -1;
-    rd_smspec->day_index = -1;
-    rd_smspec->year_index = -1;
-    rd_smspec->month_index = -1;
-    rd_smspec->time_seconds = -1;
     rd_smspec->params_size = -1;
 
     /*
@@ -493,15 +481,17 @@ rd_smspec_alloc_writer__(const char *key_join_string, const char *restart_case,
 
     {
         const rd::smspec_node *time_node;
+        int seconds_per_unit;
 
         if (time_in_days) {
-            rd_smspec->time_seconds = 3600 * 24;
+            seconds_per_unit = 3600 * 24;
             time_node = rd_smspec_add_node(rd_smspec.get(), "TIME", "DAYS", 0);
         } else {
-            rd_smspec->time_seconds = 3600;
+            seconds_per_unit = 3600;
             time_node = rd_smspec_add_node(rd_smspec.get(), "TIME", "HOURS", 0);
         }
-        rd_smspec->time_index = time_node->get_params_index();
+        rd_smspec->time_info = rd::TimeParamsIndex{
+            time_node->get_params_index(), seconds_per_unit};
     }
     return rd_smspec.release();
 }
@@ -1023,39 +1013,38 @@ rd_smspec_type *rd_smspec_fread_alloc(const std::string &header_file,
             if (time_unit == nullptr)
                 throw std::invalid_argument(
                     "TIME variable is missing a unit string");
-            rd_smspec->time_index = time_node->get_params_index();
 
+            int seconds_per_unit;
             if (util_string_equal(time_unit, "DAYS"))
-                rd_smspec->time_seconds = 3600 * 24;
+                seconds_per_unit = 3600 * 24;
             else if (util_string_equal(time_unit, "HOURS"))
-                rd_smspec->time_seconds = 3600;
+                seconds_per_unit = 3600;
             else
                 throw std::invalid_argument(
                     fmt::format("time_unit:{} not recognized", time_unit));
-        }
 
-        const rd::smspec_node *day_node =
-            rd_smspec_get_var_node(rd_smspec->misc_var_index, "DAY");
-        const rd::smspec_node *month_node =
-            rd_smspec_get_var_node(rd_smspec->misc_var_index, "MONTH");
-        const rd::smspec_node *year_node =
-            rd_smspec_get_var_node(rd_smspec->misc_var_index, "YEAR");
+            rd_smspec->time_info = rd::TimeParamsIndex{
+                time_node->get_params_index(), seconds_per_unit};
+        } else {
+            const rd::smspec_node *day_node =
+                rd_smspec_get_var_node(rd_smspec->misc_var_index, "DAY");
+            const rd::smspec_node *month_node =
+                rd_smspec_get_var_node(rd_smspec->misc_var_index, "MONTH");
+            const rd::smspec_node *year_node =
+                rd_smspec_get_var_node(rd_smspec->misc_var_index, "YEAR");
 
-        if (day_node != NULL && month_node != NULL && year_node != NULL) {
-            rd_smspec->day_index = day_node->get_params_index();
-            rd_smspec->month_index = month_node->get_params_index();
-            rd_smspec->year_index = year_node->get_params_index();
-        }
+            if (day_node == NULL || month_node == NULL || year_node == NULL)
+                // Unusable configuration.
+                // Seems the restart file can also have time specified with
+                // 'YEARS' as basic time unit; that mode is not supported.
+                throw std::invalid_argument(
+                    "The SMSPEC file seems to lack time information, need "
+                    "either TIME, or DAY/MONTH/YEAR information. Cannot "
+                    "proceed.");
 
-        if ((rd_smspec->time_index == -1) && (rd_smspec->day_index == -1)) {
-            // Unusable configuration.
-            // Seems the restart file can also have time specified with
-            // 'YEARS' as basic time unit; that mode is not supported.
-
-            throw std::invalid_argument(
-                "The SMSPEC file seems to lack all time information, need "
-                "either TIME, or DAY/MONTH/YEAR information. Can not "
-                "proceed.");
+            rd_smspec->time_info = rd::DateParamsIndex{
+                day_node->get_params_index(), month_node->get_params_index(),
+                year_node->get_params_index()};
         }
         return rd_smspec.release();
     } else {
@@ -1133,12 +1122,18 @@ bool rd_smspec_has_general_var(const rd_smspec_type *rd_smspec,
     return node_exists(node_ptr);
 }
 
-int rd_smspec_get_time_seconds(const rd_smspec_type *rd_smspec) {
-    return rd_smspec->time_seconds;
+const rd::TimeInfo &rd_smspec_get_time_info(const rd_smspec_type *smspec) {
+    return smspec->time_info;
 }
 
-int rd_smspec_get_time_index(const rd_smspec_type *rd_smspec) {
-    return rd_smspec->time_index;
+int rd_smspec_get_time_seconds(const rd_smspec_type *rd_smspec) {
+    const rd::TimeInfo &time_info = rd_smspec_get_time_info(rd_smspec);
+    if (const auto *time = std::get_if<rd::TimeParamsIndex>(&time_info))
+        return time->seconds_per_unit;
+
+    // A summary without a TIME vector has no time unit of its own; its time
+    // information is expressed as whole dates, so days is the natural scale.
+    return 3600 * 24;
 }
 
 time_t rd_smspec_get_start_time(const rd_smspec_type *rd_smspec) {
@@ -1177,18 +1172,6 @@ rd_smspec_get_params_default(const rd_smspec_type *rd_smspec) {
 }
 
 void rd_smspec_free(rd_smspec_type *rd_smspec) { delete rd_smspec; }
-
-int rd_smspec_get_date_day_index(const rd_smspec_type *smspec) {
-    return smspec->day_index;
-}
-
-int rd_smspec_get_date_month_index(const rd_smspec_type *smspec) {
-    return smspec->month_index;
-}
-
-int rd_smspec_get_date_year_index(const rd_smspec_type *smspec) {
-    return smspec->year_index;
-}
 
 /** Returns all the gen_key string matching the supplied pattern. I.e.
 

--- a/lib/resdata/rd_sum_file_data.cpp
+++ b/lib/resdata/rd_sum_file_data.cpp
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include <ert/util/util.hpp>
-#include <ert/util/vector.hpp>
 
 #include <resdata/rd_sum_tstep.hpp>
 #include <resdata/rd_kw.hpp>
@@ -205,9 +204,9 @@ void validate_report_step(int report_step) {
 namespace rd {
 
 rd_sum_file_data::rd_sum_file_data(const rd_smspec_type *smspec)
-    : rd_smspec(smspec), data(vector_alloc_new()) {}
+    : rd_smspec(smspec) {}
 
-rd_sum_file_data::~rd_sum_file_data() { vector_free(data); }
+rd_sum_file_data::~rd_sum_file_data() = default;
 
 int rd_sum_file_data::length() const {
     if (this->loader)
@@ -284,15 +283,6 @@ double rd_sum_file_data::iget(int time_index, int params_index) const {
     }
 }
 
-void rd_sum_file_data::append_tstep(rd_sum_tstep_type *tstep) {
-    /*
-     Here the tstep is just appended naively, the vector will be
-     sorted by ministep_nr before the data instance is returned.
-  */
-
-    vector_append_owned_ref(data, tstep, rd_sum_tstep_free__);
-}
-
 /*
   This function is meant to be called in write mode; and will create a
   new and empty tstep which is appended to the current data. The tstep
@@ -304,18 +294,17 @@ rd_sum_tstep_type *rd_sum_file_data::add_new_tstep(int report_step,
                                                    double sim_seconds) {
     validate_report_step(report_step);
 
-    int ministep_nr = vector_get_size(data);
-    std::unique_ptr<rd_sum_tstep_type, decltype(&rd_sum_tstep_free)> tstep(
-        rd_sum_tstep_alloc_new(report_step, ministep_nr, sim_seconds,
-                               rd_smspec),
-        &rd_sum_tstep_free);
+    int ministep_nr = static_cast<int>(data.size());
+    rd_sum_tstep_ptr tstep(rd_sum_tstep_alloc_new(report_step, ministep_nr,
+                                                  sim_seconds, rd_smspec),
+                           &rd_sum_tstep_free);
     rd_sum_tstep_type *prev_tstep = NULL;
 
-    if (vector_get_size(data) > 0)
-        prev_tstep = (rd_sum_tstep_type *)vector_get_last(data);
+    if (!data.empty())
+        prev_tstep = data.back().get();
 
     rd_sum_tstep_type *new_tstep = tstep.get();
-    append_tstep(tstep.release());
+    data.push_back(std::move(tstep));
 
     bool rebuild_index = true;
     /*
@@ -347,7 +336,7 @@ exit:
 }
 
 rd_sum_tstep_type *rd_sum_file_data::iget_ministep(int internal_index) const {
-    return (rd_sum_tstep_type *)vector_iget(data, internal_index);
+    return data.at(internal_index).get();
 }
 
 double rd_sum_file_data::iget_sim_days(int time_index) const {
@@ -360,19 +349,10 @@ double rd_sum_file_data::iget_sim_seconds(int time_index) const {
     return node.sim_seconds;
 }
 
-static int cmp_ministep(const void *arg1, const void *arg2) {
-    const rd_sum_tstep_type *ministep1 = rd_sum_tstep_safe_cast_const(arg1);
-    const rd_sum_tstep_type *ministep2 = rd_sum_tstep_safe_cast_const(arg2);
-
-    time_t time1 = rd_sum_tstep_get_sim_time(ministep1);
-    time_t time2 = rd_sum_tstep_get_sim_time(ministep2);
-
-    if (time1 < time2)
-        return -1;
-    else if (time1 == time2)
-        return 0;
-    else
-        return 1;
+static bool cmp_ministep(const rd_sum_tstep_ptr &ministep1,
+                         const rd_sum_tstep_ptr &ministep2) {
+    return rd_sum_tstep_get_sim_time(ministep1.get()) <
+           rd_sum_tstep_get_sim_time(ministep2.get());
 }
 
 void rd_sum_file_data::build_index() {
@@ -388,14 +368,11 @@ void rd_sum_file_data::build_index() {
             this->index.add(sim_time[i], sim_seconds[i], report_steps[i]);
         }
     } else {
-        vector_sort(data, cmp_ministep);
-        for (int internal_index = 0; internal_index < vector_get_size(data);
-             internal_index++) {
-            const rd_sum_tstep_type *ministep = iget_ministep(internal_index);
-            this->index.add(rd_sum_tstep_get_sim_time(ministep),
-                            rd_sum_tstep_get_sim_seconds(ministep),
-                            rd_sum_tstep_get_report(ministep));
-        }
+        std::stable_sort(data.begin(), data.end(), cmp_ministep);
+        for (const auto &ministep : data)
+            this->index.add(rd_sum_tstep_get_sim_time(ministep.get()),
+                            rd_sum_tstep_get_sim_seconds(ministep.get()),
+                            rd_sum_tstep_get_report(ministep.get()));
     }
 }
 
@@ -562,14 +539,13 @@ void rd_sum_file_data::add_rd_file(int report_step,
             {
                 int ministep_nr = rd_kw_iget_int(ministep_kw, 0);
                 std::string filename = summary_view.filename();
-                std::unique_ptr<rd_sum_tstep_type, decltype(&rd_sum_tstep_free)>
-                    tstep(rd_sum_tstep_alloc_from_file(
-                              report_step, ministep_nr, params_kw,
-                              filename.c_str(), this->rd_smspec),
-                          &rd_sum_tstep_free);
+                rd_sum_tstep_ptr tstep(rd_sum_tstep_alloc_from_file(
+                                           report_step, ministep_nr, params_kw,
+                                           filename.c_str(), this->rd_smspec),
+                                       &rd_sum_tstep_free);
 
                 if (tstep)
-                    append_tstep(tstep.release());
+                    data.push_back(std::move(tstep));
             }
         }
     }

--- a/lib/resdata/rd_sum_tstep.cpp
+++ b/lib/resdata/rd_sum_tstep.cpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <stdexcept>
+#include <variant>
 #include <vector>
 #include <fmt/format.h>
 
@@ -119,26 +120,22 @@ static void rd_sum_tstep_set_time_info_from_date(rd_sum_tstep_type *tstep,
 
 static void rd_sum_tstep_set_time_info(rd_sum_tstep_type *tstep,
                                        const rd_smspec_type *smspec) {
-    int date_day_index = rd_smspec_get_date_day_index(smspec);
-    int date_month_index = rd_smspec_get_date_month_index(smspec);
-    int date_year_index = rd_smspec_get_date_year_index(smspec);
-    int sim_time_index = rd_smspec_get_time_index(smspec);
     time_t sim_start = rd_smspec_get_start_time(smspec);
+    const rd::TimeInfo &time_info = rd_smspec_get_time_info(smspec);
 
-    if (sim_time_index >= 0) {
-        double sim_time = tstep->data[sim_time_index];
-        double sim_seconds = sim_time * rd_smspec_get_time_seconds(smspec);
+    if (const auto *time = std::get_if<rd::TimeParamsIndex>(&time_info)) {
+        double sim_time = tstep->data[time->params_index];
+        double sim_seconds = sim_time * time->seconds_per_unit;
         rd_sum_tstep_set_time_info_from_seconds(tstep, sim_start, sim_seconds);
-    } else if (date_day_index >= 0) {
-        int day = util_roundf(tstep->data[date_day_index]);
-        int month = util_roundf(tstep->data[date_month_index]);
-        int year = util_roundf(tstep->data[date_year_index]);
+    } else {
+        const auto &date = std::get<rd::DateParamsIndex>(time_info);
+        int day = util_roundf(tstep->data[date.day]);
+        int month = util_roundf(tstep->data[date.month]);
+        int year = util_roundf(tstep->data[date.year]);
 
         time_t sim_time = rd_make_date(day, month, year);
         rd_sum_tstep_set_time_info_from_date(tstep, sim_start, sim_time);
-    } else
-        throw std::invalid_argument(
-            "Could not extract date/time information from SMSPEC header file.");
+    }
 }
 
 /**
@@ -190,8 +187,13 @@ rd_sum_tstep_type *rd_sum_tstep_alloc_new(int report_step, int ministep,
 
     rd_sum_tstep_set_time_info_from_seconds(
         tstep.get(), rd_smspec_get_start_time(smspec), sim_seconds);
-    rd_sum_tstep_iset(tstep.get(), rd_smspec_get_time_index(smspec),
-                      sim_seconds / rd_smspec_get_time_seconds(smspec));
+    const auto *time =
+        std::get_if<rd::TimeParamsIndex>(&rd_smspec_get_time_info(smspec));
+    if (time == nullptr)
+        throw std::invalid_argument("Cannot create a new summary timestep for "
+                                    "a SMSPEC without a TIME variable");
+    rd_sum_tstep_iset(tstep.get(), time->params_index,
+                      sim_seconds / time->seconds_per_unit);
     return tstep.release();
 }
 

--- a/lib/resdata/rd_sum_tstep.cpp
+++ b/lib/resdata/rd_sum_tstep.cpp
@@ -76,11 +76,6 @@ UTIL_SAFE_CAST_FUNCTION_CONST(rd_sum_tstep, RD_SUM_TSTEP_ID)
 
 void rd_sum_tstep_free(rd_sum_tstep_type *ministep) { delete ministep; }
 
-void rd_sum_tstep_free__(void *__ministep) {
-    rd_sum_tstep_type *ministep = rd_sum_tstep_safe_cast(__ministep);
-    rd_sum_tstep_free(ministep);
-}
-
 /**
    This function sets the internal time representation in the
    rd_sum_tstep. The treatment of time is a bit weird; on the one

--- a/lib/resdata/rd_unsmry_loader.cpp
+++ b/lib/resdata/rd_unsmry_loader.cpp
@@ -1,8 +1,10 @@
 #include <ctime>
+#include <memory>
 #include <new>
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <ert/util/int_vector.hpp>
@@ -12,7 +14,6 @@
 #include <resdata/rd_file.hpp>
 #include <resdata/rd_file_flag.hpp>
 #include <resdata/rd_file_view.hpp>
-#include <resdata/rd_file_kw.hpp>
 #include <resdata/rd_kw.hpp>
 #include <resdata/rd_smspec.hpp>
 #include <resdata/rd_type.hpp>
@@ -25,8 +26,7 @@ namespace rd {
 unsmry_loader::unsmry_loader(const rd_smspec_type *smspec,
                              const std::string &filename, FileMode file_options)
     : size(rd_smspec_get_params_size(smspec)),
-      time_index(rd_smspec_get_time_index(smspec)),
-      time_seconds(rd_smspec_get_time_seconds(smspec)),
+      time_info(rd_smspec_get_time_info(smspec)),
       sim_start(rd_smspec_get_start_time(smspec)) {
     {
         std::unique_ptr<rd::File> file = rd::File::open(filename, file_options);
@@ -41,9 +41,8 @@ unsmry_loader::unsmry_loader(const rd_smspec_type *smspec,
         throw std::bad_alloc();
     }
 
-    this->date_index = {{rd_smspec_get_date_day_index(smspec),
-                         rd_smspec_get_date_month_index(smspec),
-                         rd_smspec_get_date_year_index(smspec)}};
+    if (const auto *date = std::get_if<rd::DateParamsIndex>(&this->time_info))
+        this->date_index = {{date->day, date->month, date->year}};
     auto file_view = this->file->get_global_view();
     int length = file_view->num_named_kw(PARAMS_KW);
 
@@ -97,7 +96,7 @@ double unsmry_loader::iget(int time_index, int params_index) const {
 }
 
 time_t unsmry_loader::iget_sim_time(int time_index) const {
-    if (this->time_index >= 0) {
+    if (std::holds_alternative<rd::TimeParamsIndex>(this->time_info)) {
         double sim_seconds = this->iget_sim_seconds(time_index);
         time_t sim_time = this->sim_start;
         util_inplace_forward_seconds_utc(&sim_time, sim_seconds);
@@ -118,9 +117,9 @@ time_t unsmry_loader::iget_sim_time(int time_index) const {
 }
 
 double unsmry_loader::iget_sim_seconds(int time_index) const {
-    if (this->time_index >= 0) {
-        double raw_time = this->iget(time_index, this->time_index);
-        return raw_time * this->time_seconds;
+    if (const auto *time = std::get_if<rd::TimeParamsIndex>(&this->time_info)) {
+        double raw_time = this->iget(time_index, time->params_index);
+        return raw_time * time->seconds_per_unit;
     } else {
         time_t sim_time = this->iget_sim_time(time_index);
         return util_difftime_seconds(this->sim_start, sim_time);
@@ -141,7 +140,7 @@ std::vector<int> unsmry_loader::report_steps(int offset) const {
 }
 
 std::vector<time_t> unsmry_loader::sim_time() const {
-    if (this->time_index >= 0) {
+    if (std::holds_alternative<rd::TimeParamsIndex>(this->time_info)) {
         const std::vector<double> sim_seconds = this->sim_seconds();
         std::vector<time_t> st(this->length(), this->sim_start);
 
@@ -165,10 +164,10 @@ std::vector<time_t> unsmry_loader::sim_time() const {
 }
 
 std::vector<double> unsmry_loader::sim_seconds() const {
-    if (this->time_index >= 0) {
-        std::vector<double> seconds = this->get_vector(this->time_index);
+    if (const auto *time = std::get_if<rd::TimeParamsIndex>(&this->time_info)) {
+        std::vector<double> seconds = this->get_vector(time->params_index);
         for (size_t i = 0; i < seconds.size(); i++)
-            seconds[i] *= this->time_seconds;
+            seconds[i] *= time->seconds_per_unit;
 
         return seconds;
     } else {

--- a/lib/resdata/rd_util.cpp
+++ b/lib/resdata/rd_util.cpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 #include <algorithm>
 #include <ert/util/ert_api_config.hpp>
@@ -79,62 +80,52 @@ int rd_filename_report_nr(const char *filename) {
     return report_nr;
 }
 
+namespace {
+struct ExtInfo {
+    FileType type;
+    bool fmt_file;
+};
+
+const std::unordered_map<std::string_view, ExtInfo> &ext_type_map() {
+    static const std::unordered_map<std::string_view, ExtInfo> m = {
+        {"UNRST", {FileType::UNIFIED_RESTART, false}},
+        {"FUNRST", {FileType::UNIFIED_RESTART, true}},
+        {"UNSMRY", {FileType::UNIFIED_SUMMARY, false}},
+        {"FUNSMRY", {FileType::UNIFIED_SUMMARY, true}},
+        {"SMSPEC", {FileType::SUMMARY_HEADER, false}},
+        {"FSMSPEC", {FileType::SUMMARY_HEADER, true}},
+        {"GRID", {FileType::GRID, false}},
+        {"FGRID", {FileType::GRID, true}},
+        {"EGRID", {FileType::EGRID, false}},
+        {"FEGRID", {FileType::EGRID, true}},
+        {"INIT", {FileType::INIT, false}},
+        {"FINIT", {FileType::INIT, true}},
+        {"FRFT", {FileType::RFT, true}},
+        {"RFT", {FileType::RFT, false}},
+        {"DATA", {FileType::DATA, true}},
+    };
+    return m;
+}
+
 /*
  We accept mixed lowercase/uppercase Eclipse file extensions even if Eclipse itself does not accept them.
 */
-static FileType rd_inspect_extension(const char *ext, bool *_fmt_file,
-                                     int *_report_nr) {
+static FileType inspect_extension(std::string_view ext, bool *_fmt_file,
+                                  int *_report_nr) {
     FileType file_type = FileType::OTHER;
     bool fmt_file = true;
     int report_nr = -1;
-    char *upper_ext = util_alloc_strupr_copy(ext);
-    if (strcmp(upper_ext, "UNRST") == 0) {
-        file_type = FileType::UNIFIED_RESTART;
-        fmt_file = false;
-    } else if (strcmp(upper_ext, "FUNRST") == 0) {
-        file_type = FileType::UNIFIED_RESTART;
-        fmt_file = true;
-    } else if (strcmp(upper_ext, "UNSMRY") == 0) {
-        file_type = FileType::UNIFIED_SUMMARY;
-        fmt_file = false;
-    } else if (strcmp(upper_ext, "FUNSMRY") == 0) {
-        file_type = FileType::UNIFIED_SUMMARY;
-        fmt_file = true;
-    } else if (strcmp(upper_ext, "SMSPEC") == 0) {
-        file_type = FileType::SUMMARY_HEADER;
-        fmt_file = false;
-    } else if (strcmp(upper_ext, "FSMSPEC") == 0) {
-        file_type = FileType::SUMMARY_HEADER;
-        fmt_file = true;
-    } else if (strcmp(upper_ext, "GRID") == 0) {
-        file_type = FileType::GRID;
-        fmt_file = false;
-    } else if (strcmp(upper_ext, "FGRID") == 0) {
-        file_type = FileType::GRID;
-        fmt_file = true;
-    } else if (strcmp(upper_ext, "EGRID") == 0) {
-        file_type = FileType::EGRID;
-        fmt_file = false;
-    } else if (strcmp(upper_ext, "FEGRID") == 0) {
-        file_type = FileType::EGRID;
-        fmt_file = true;
-    } else if (strcmp(upper_ext, "INIT") == 0) {
-        file_type = FileType::INIT;
-        fmt_file = false;
-    } else if (strcmp(upper_ext, "FINIT") == 0) {
-        file_type = FileType::INIT;
-        fmt_file = true;
-    } else if (strcmp(upper_ext, "FRFT") == 0) {
-        file_type = FileType::RFT;
-        fmt_file = true;
-    } else if (strcmp(upper_ext, "RFT") == 0) {
-        file_type = FileType::RFT;
-        fmt_file = false;
-    } else if (strcmp(upper_ext, "DATA") == 0) {
-        file_type = FileType::DATA;
-        fmt_file = true; /* Not really relevant ... */
+
+    std::string upper_ext(ext);
+    for (char &c : upper_ext)
+        c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+
+    auto it = ext_type_map().find(std::string_view(upper_ext));
+    if (it != ext_type_map().end()) {
+        file_type = it->second.type;
+        fmt_file = it->second.fmt_file;
     } else {
-        switch (upper_ext[0]) {
+        switch (upper_ext.empty() ? '\0' : upper_ext[0]) {
         case ('X'):
             file_type = FileType::RESTART;
             fmt_file = false;
@@ -155,7 +146,7 @@ static FileType rd_inspect_extension(const char *ext, bool *_fmt_file,
             file_type = FileType::OTHER;
         }
         if (file_type != FileType::OTHER)
-            if (!util_sscanf_int(&upper_ext[1], &report_nr))
+            if (!util_sscanf_int(upper_ext.c_str() + 1, &report_nr))
                 file_type = FileType::OTHER;
     }
 
@@ -164,10 +155,9 @@ static FileType rd_inspect_extension(const char *ext, bool *_fmt_file,
 
     if (_report_nr != NULL)
         *_report_nr = report_nr;
-
-    free(upper_ext);
     return file_type;
 }
+} // namespace
 
 /**
   This function takes an eclipse filename as input - looks at the
@@ -183,7 +173,7 @@ FileType rd_get_file_type(const char *filename, bool *fmt_file,
     if (ext == NULL)
         return FileType::OTHER;
 
-    return rd_inspect_extension(&ext[1], fmt_file, report_nr);
+    return inspect_extension(&ext[1], fmt_file, report_nr);
 }
 
 static const char *rd_get_file_pattern(FileType file_type, bool fmt_file) {
@@ -402,8 +392,7 @@ fs::path filename(fs::path casepath, FileType file_type, bool fmt_file,
 
     return casepath.parent_path() / (base + "." + ext);
 }
-}; // namespace rd
-
+} // namespace rd
 /**
    This function assumes that:
 
@@ -733,45 +722,29 @@ bool rd_fmt_file(const char *filename, bool *__fmt_file) {
    Will return -1 for an unrecognized month name.
 */
 
-static int rd_get_month_nr__(const char *_month_name) {
-    int month_nr = -1;
-    char *month_name = util_alloc_string_copy(_month_name);
-    util_strupr(month_name);
+static int rd_get_month_nr__(const char *month_name_) {
+    constexpr size_t month_len = 3;
 
-    if (strncmp(month_name, "JAN", 3) == 0)
-        month_nr = 1;
-    else if (strncmp(month_name, "FEB", 3) == 0)
-        month_nr = 2;
-    else if (strncmp(month_name, "MAR", 3) == 0)
-        month_nr = 3;
-    else if (strncmp(month_name, "APR", 3) == 0)
-        month_nr = 4;
-    else if (strncmp(month_name, "MAI", 3) == 0)
-        month_nr = 5;
-    else if (strncmp(month_name, "MAY", 3) == 0)
-        month_nr = 5;
-    else if (strncmp(month_name, "JUN", 3) == 0)
-        month_nr = 6;
-    else if (strncmp(month_name, "JUL", 3) == 0)
-        month_nr = 7;
-    else if (strncmp(month_name, "JLY", 3) == 0) /* ECLIPSE ambigus on July. */
-        month_nr = 7;
-    else if (strncmp(month_name, "AUG", 3) == 0)
-        month_nr = 8;
-    else if (strncmp(month_name, "SEP", 3) == 0)
-        month_nr = 9;
-    else if (strncmp(month_name, "OCT", 3) == 0)
-        month_nr = 10;
-    else if (strncmp(month_name, "OKT", 3) == 0)
-        month_nr = 10;
-    else if (strncmp(month_name, "NOV", 3) == 0)
-        month_nr = 11;
-    else if (strncmp(month_name, "DEC", 3) == 0)
-        month_nr = 12;
-    else if (strncmp(month_name, "DES", 3) == 0)
-        month_nr = 12;
-    free(month_name);
-    return month_nr;
+    /* Guard against reading past the end of short/malformed input before
+       touching any of its bytes. */
+    if (strnlen(month_name_, month_len) != month_len)
+        return -1;
+
+    char upper_month[month_len + 1];
+    for (size_t i = 0; i < month_len; ++i)
+        upper_month[i] = static_cast<char>(
+            std::toupper(static_cast<unsigned char>(month_name_[i])));
+    upper_month[month_len] = '\0';
+
+    static const std::unordered_map<std::string_view, int> month_map = {
+        {"JAN", 1},  {"FEB", 2},  {"MAR", 3},  {"APR", 4},
+        {"MAI", 5},  {"MAY", 5},  {"JUN", 6},  {"JUL", 7},
+        {"JLY", 7},  {"AUG", 8},  {"SEP", 9},  {"OCT", 10},
+        {"OKT", 10}, {"NOV", 11}, {"DEC", 12}, {"DES", 12},
+    };
+
+    auto it = month_map.find(std::string_view(upper_month, month_len));
+    return it != month_map.end() ? it->second : -1;
 }
 
 static int rd_get_month_nr(const char *month_name) {
@@ -793,37 +766,39 @@ static int rd_get_month_nr(const char *month_name) {
 */
 
 time_t rd_get_start_date(const char *data_file) {
-    basic_parser_type *parser =
-        basic_parser_alloc(" \t\r\n", "\"\'", NULL, NULL, "--", "\n");
+    parser_ptr parser{
+        basic_parser_alloc(" \t\r\n", "\"\'", NULL, NULL, "--", "\n")};
     time_t start_date = -1;
-    FILE *stream = util_fopen(data_file, "r");
-    char *buffer;
+    std::unique_ptr<FILE, void (*)(FILE *)> stream{util_fopen(data_file, "r"),
+                                                   [](FILE *f) { fclose(f); }};
+    std::vector<char> buffer;
 
-    if (!basic_parser_fseek_string(parser, stream, "START", true,
+    if (!basic_parser_fseek_string(parser.get(), stream.get(), "START", true,
                                    true)) /* Seeks case insensitive. */
         util_abort("%s: sorry - could not find START in DATA file %s \n",
                    __func__, data_file);
 
     {
-        long int start_pos = util_ftell(stream);
-        int buffer_size;
+        offset_type start_pos = util_ftell(stream.get());
 
         /* Look for terminating '/' */
-        if (!basic_parser_fseek_string(parser, stream, "/", false, true))
+        if (!basic_parser_fseek_string(parser.get(), stream.get(), "/", false,
+                                       true))
             util_abort("%s: sorry - could not find \"/\" termination of START "
                        "keyword in data_file: \n",
                        __func__, data_file);
 
-        buffer_size = (util_ftell(stream) - start_pos);
-        buffer = (char *)util_calloc(buffer_size + 1, sizeof *buffer);
-        util_fseek(stream, start_pos, SEEK_SET);
-        util_fread(buffer, sizeof *buffer, buffer_size, stream, __func__);
-        buffer[buffer_size] = '\0';
+        size_t buffer_size =
+            static_cast<size_t>(util_ftell(stream.get()) - start_pos);
+        buffer.assign(buffer_size + 1, '\0');
+        util_fseek(stream.get(), start_pos, SEEK_SET);
+        util_fread(buffer.data(), sizeof(char), buffer_size, stream.get(),
+                   __func__);
     }
 
     {
         stringlist_type *tokens =
-            basic_parser_tokenize_buffer(parser, buffer, true);
+            basic_parser_tokenize_buffer(parser.get(), buffer.data(), true);
         int day, year, month_nr;
         if (util_sscanf_int(stringlist_iget(tokens, 0), &day) &&
             util_sscanf_int(stringlist_iget(tokens, 2), &year)) {
@@ -831,13 +806,9 @@ time_t rd_get_start_date(const char *data_file) {
             start_date = rd_make_date(day, month_nr, year);
         } else
             util_abort("%s: failed to parse DAY MONTH YEAR from : \"%s\" \n",
-                       __func__, buffer);
+                       __func__, buffer.data());
         stringlist_free(tokens);
     }
-
-    free(buffer);
-    basic_parser_free(parser);
-    fclose(stream);
 
     return start_date;
 }
@@ -845,9 +816,8 @@ time_t rd_get_start_date(const char *data_file) {
 static int rd_get_num_parallel_cpu__(basic_parser_type *parser, FILE *stream,
                                      const char *data_file) {
     int num_cpu = 1;
-    char *buffer;
-    long int start_pos = util_ftell(stream);
-    int buffer_size;
+    std::vector<char> buffer;
+    offset_type start_pos = util_ftell(stream);
 
     /* Look for terminating '/' */
     if (!basic_parser_fseek_string(parser, stream, "/", false, true))
@@ -855,15 +825,14 @@ static int rd_get_num_parallel_cpu__(basic_parser_type *parser, FILE *stream,
                    "keyword in data_file: \n",
                    __func__, data_file);
 
-    buffer_size = (util_ftell(stream) - start_pos);
-    buffer = (char *)util_calloc(buffer_size + 1, sizeof *buffer);
+    size_t buffer_size = static_cast<size_t>(util_ftell(stream) - start_pos);
+    buffer.assign(buffer_size + 1, '\0');
     util_fseek(stream, start_pos, SEEK_SET);
-    util_fread(buffer, sizeof *buffer, buffer_size, stream, __func__);
-    buffer[buffer_size] = '\0';
+    util_fread(buffer.data(), sizeof(char), buffer_size, stream, __func__);
 
     {
         stringlist_type *tokens =
-            basic_parser_tokenize_buffer(parser, buffer, true);
+            basic_parser_tokenize_buffer(parser, buffer.data(), true);
 
         if (stringlist_get_size(tokens) > 0) {
             const char *num_cpu_string = stringlist_iget(tokens, 0);
@@ -878,7 +847,6 @@ static int rd_get_num_parallel_cpu__(basic_parser_type *parser, FILE *stream,
 
         stringlist_free(tokens);
     }
-    free(buffer);
     return num_cpu;
 }
 
@@ -941,7 +909,7 @@ static int rd_get_num_slave_cpu__(basic_parser_type *parser, FILE *stream,
    and (possibly) blank lines between the title keyword and the title. */
 static bool rd_find_keyword__(basic_parser_type *parser, FILE *stream,
                               const char *keyword) {
-    long int title_pos = -1;
+    offset_type title_pos = -1;
 
     /* Find the first occurenced of TITLE, if any. */
     if (basic_parser_fseek_string(parser, stream, "TITLE", false, true)) {
@@ -951,7 +919,7 @@ static bool rd_find_keyword__(basic_parser_type *parser, FILE *stream,
 
     /* Find all keyword occurences, returning the first that is valid. */
     while (basic_parser_fseek_string(parser, stream, keyword, false, true)) {
-        long int keyword_pos = util_ftell(stream);
+        offset_type keyword_pos = util_ftell(stream);
 
         /* Starting with last title found, find all titles that start before
            this keyword occurence, to see if they contain the keyword: */
@@ -986,7 +954,9 @@ static bool rd_find_keyword__(basic_parser_type *parser, FILE *stream,
 
         /* Position to the end of the keyword, we either are succesful, or we
            need to continue looking for the next keyword. */
-        util_fseek(stream, keyword_pos + strlen(keyword), SEEK_SET);
+        util_fseek(stream,
+                   keyword_pos + static_cast<offset_type>(strlen(keyword)),
+                   SEEK_SET);
 
         /* If we are not within a title: success. */
         if (title_pos < 0 || keyword_pos < title_pos)
@@ -998,22 +968,23 @@ static bool rd_find_keyword__(basic_parser_type *parser, FILE *stream,
 
 int rd_get_num_cpu(const char *data_file) {
     int num_cpu = 1;
-    basic_parser_type *parser =
-        basic_parser_alloc(" \t\r\n", "\"\'", NULL, NULL, "--", "\n");
-    FILE *stream = util_fopen(data_file, "r");
+    parser_ptr parser{
+        basic_parser_alloc(" \t\r\n", "\"\'", NULL, NULL, "--", "\n")};
+    std::unique_ptr<FILE, void (*)(FILE *)> stream{util_fopen(data_file, "r"),
+                                                   [](FILE *f) { fclose(f); }};
 
-    if (rd_find_keyword__(parser, stream, "PARALLEL")) {
-        num_cpu = rd_get_num_parallel_cpu__(parser, stream, data_file);
-    } else if (rd_find_keyword__(parser, stream, "SLAVES")) {
-        num_cpu = rd_get_num_slave_cpu__(parser, stream, data_file) + 1;
+    if (rd_find_keyword__(parser.get(), stream.get(), "PARALLEL")) {
+        num_cpu =
+            rd_get_num_parallel_cpu__(parser.get(), stream.get(), data_file);
+    } else if (rd_find_keyword__(parser.get(), stream.get(), "SLAVES")) {
+        num_cpu =
+            rd_get_num_slave_cpu__(parser.get(), stream.get(), data_file) + 1;
         fprintf(stderr,
                 "Information: \"SLAVES\" option found, returning %d number "
                 "of CPUs",
                 num_cpu);
     }
 
-    basic_parser_free(parser);
-    fclose(stream);
     return num_cpu;
 }
 

--- a/lib/resdata/tests/rd_layer.cpp
+++ b/lib/resdata/tests/rd_layer.cpp
@@ -1,5 +1,6 @@
 #include <stdexcept>
 #include <vector>
+#include <set>
 
 #include <ert/util/test_util.hpp>
 
@@ -112,7 +113,7 @@ void test_edge() {
 void test_walk() {
     layer_type *layer = layer_alloc(10, 10);
     std::vector<int_point2d_type> corner_list;
-    int_vector_type *cell_list = int_vector_alloc(0, 0);
+    std::vector<int> cell_list;
 
     test_assert_false(
         layer_trace_block_edge(layer, 4, 4, 100, corner_list, cell_list));
@@ -123,7 +124,8 @@ void test_walk() {
     test_assert_true(
         layer_trace_block_edge(layer, 4, 4, 100, corner_list, cell_list));
     test_assert_int_equal(corner_list.size(), 4);
-    test_assert_int_equal(int_vector_size(cell_list), 1);
+    test_assert_size_t_equal(
+        std::set(cell_list.begin(), cell_list.end()).size(), 1);
     {
         test_assert_int_equal(4, corner_list[0].i);
         test_assert_int_equal(4, corner_list[0].j);
@@ -140,35 +142,28 @@ void test_walk() {
 
     {
         int i, j;
-        int_vector_type *true_cell_list = int_vector_alloc(0, 0);
+        std::set<int> true_cell_set;
         for (j = 3; j < 7; j++) {
             for (i = 3; i < 7; i++) {
                 layer_iset_cell_value(layer, i, j, 100);
 
                 if (i == 3 || j == 3)
-                    int_vector_append(true_cell_list,
-                                      i + j * layer_get_nx(layer));
+                    true_cell_set.insert(i + j * layer_get_nx(layer));
 
                 if (i == 6 || j == 6)
-                    int_vector_append(true_cell_list,
-                                      i + j * layer_get_nx(layer));
+                    true_cell_set.insert(i + j * layer_get_nx(layer));
             }
         }
-        int_vector_select_unique(true_cell_list);
 
         test_assert_true(
             layer_trace_block_edge(layer, 3, 3, 100, corner_list, cell_list));
         test_assert_int_equal(16, corner_list.size());
-        test_assert_int_equal(12, int_vector_size(cell_list));
+        std::set<int> cell_set(cell_list.begin(), cell_list.end());
+        test_assert_size_t_equal(12, cell_set.size());
 
-        int_vector_fprintf(cell_list, stdout, "     cell_list", "%3d");
-        int_vector_fprintf(true_cell_list, stdout, "true_cell_list", "%3d");
-
-        test_assert_true(int_vector_equal(cell_list, true_cell_list));
-        int_vector_free(true_cell_list);
+        test_assert_true(cell_set == true_cell_set);
     }
 
-    int_vector_free(cell_list);
     layer_free(layer);
 }
 
@@ -230,7 +225,7 @@ void test_content2() {
     {
         int_vector_type *i_list = int_vector_alloc(0, 0);
         int_vector_type *j_list = int_vector_alloc(0, 0);
-        int_vector_type *cell_list = int_vector_alloc(0, 0);
+        std::vector<int> cell_list;
         std::vector<int_point2d_type> corner_list;
 
         for (j = 0; j < 5; j++) {
@@ -248,7 +243,6 @@ void test_content2() {
 
         int_vector_free(i_list);
         int_vector_free(j_list);
-        int_vector_free(cell_list);
     }
     test_assert_int_equal(0, layer_get_cell_sum(layer));
 

--- a/lib/resdata/tests/rd_layer.cpp
+++ b/lib/resdata/tests/rd_layer.cpp
@@ -6,7 +6,6 @@
 
 #include <resdata/layer.hpp>
 #include "detail/resdata/layer_cxx.hpp"
-#include "ert/util/int_vector.hpp"
 
 void test_get_cell() {
     layer_type *layer = layer_alloc(10, 10);
@@ -175,39 +174,16 @@ void test_content1() {
             layer_iset_cell_value(layer, i, j, 1);
 
     test_assert_int_equal(16, layer_get_cell_sum(layer));
-    {
-        int_vector_type *i_list = int_vector_alloc(0, 0);
-        int_vector_type *j_list = int_vector_alloc(0, 0);
+    test_assert_true(layer_trace_block_content(layer, false, 4, 4, 10).empty());
+    test_assert_size_t_equal(
+        16, layer_trace_block_content(layer, false, 4, 4, 1).size());
 
-        test_assert_false(
-            layer_trace_block_content(layer, false, 4, 4, 10, i_list, j_list));
-        test_assert_true(
-            layer_trace_block_content(layer, false, 4, 4, 1, i_list, j_list));
-        test_assert_int_equal(16, int_vector_size(i_list));
+    test_assert_size_t_equal(
+        16, layer_trace_block_content(layer, false, 4, 4, 0).size());
 
-        int_vector_sort(i_list);
-        int_vector_sort(j_list);
-
-        for (j = 0; j < 4; j++)
-            for (i = 0; i < 4; i++) {
-                test_assert_int_equal(int_vector_iget(i_list, i + j * 4),
-                                      j + 4);
-                test_assert_int_equal(int_vector_iget(j_list, i + j * 4),
-                                      j + 4);
-            }
-
-        test_assert_true(
-            layer_trace_block_content(layer, false, 4, 4, 0, i_list, j_list));
-        test_assert_int_equal(16, int_vector_size(i_list));
-
-        test_assert_true(
-            layer_trace_block_content(layer, true, 4, 4, 0, i_list, j_list));
-        test_assert_int_equal(16, int_vector_size(i_list));
-        test_assert_int_equal(0, layer_get_cell_sum(layer));
-
-        int_vector_free(i_list);
-        int_vector_free(j_list);
-    }
+    test_assert_size_t_equal(
+        16, layer_trace_block_content(layer, true, 4, 4, 0).size());
+    test_assert_int_equal(0, layer_get_cell_sum(layer));
 
     layer_free(layer);
 }
@@ -223,8 +199,6 @@ void test_content2() {
 
     test_assert_int_equal(9, layer_get_cell_sum(layer));
     {
-        int_vector_type *i_list = int_vector_alloc(0, 0);
-        int_vector_type *j_list = int_vector_alloc(0, 0);
         std::vector<int> cell_list;
         std::vector<int_point2d_type> corner_list;
 
@@ -235,14 +209,12 @@ void test_content2() {
                 if (cell_value != 0) {
                     test_assert_true(layer_trace_block_edge(
                         layer, i, j, cell_value, corner_list, cell_list));
-                    test_assert_true(layer_trace_block_content(
-                        layer, true, i, j, cell_value, i_list, j_list));
+                    test_assert_true(
+                        layer_trace_block_content(layer, true, i, j, cell_value)
+                            .size() > 0);
                 }
             }
         }
-
-        int_vector_free(i_list);
-        int_vector_free(j_list);
     }
     test_assert_int_equal(0, layer_get_cell_sum(layer));
 

--- a/lib/resdata/tests/rd_nnc_info_test.cpp
+++ b/lib/resdata/tests/rd_nnc_info_test.cpp
@@ -59,7 +59,6 @@ void basic_test() {
 
     test_assert_int_equal(0, nnc_info_get_total_size(nnc_info));
     test_assert_int_equal(lgr_nr, nnc_info_get_lgr_nr(nnc_info));
-    test_assert_true(nnc_info_is_instance(nnc_info));
     test_assert_not_NULL(nnc_info);
 
     nnc_info_add_nnc(nnc_info, lgr_nr, 110, 0);

--- a/lib/resdata/tests/rd_nnc_vector.cpp
+++ b/lib/resdata/tests/rd_nnc_vector.cpp
@@ -10,7 +10,6 @@ void test_basic() {
     int lgr_nr = 100;
     nnc_vector_type *vector = nnc_vector_alloc(lgr_nr);
 
-    test_assert_true(nnc_vector_is_instance(vector));
     test_assert_int_equal(lgr_nr, nnc_vector_get_lgr_nr(vector));
 
     nnc_vector_add_nnc(vector, 100, 1);
@@ -66,7 +65,6 @@ void test_copy() {
     test_assert_false(nnc_vector_equal(vector1, vector2));
 
     vector3 = nnc_vector_alloc_copy(vector1);
-    test_assert_true(nnc_vector_is_instance(vector3));
     test_assert_true(nnc_vector_equal(vector1, vector3));
 
     nnc_vector_free(vector1);

--- a/lib/resdata/tests/well_branch_collection.cpp
+++ b/lib/resdata/tests/well_branch_collection.cpp
@@ -19,9 +19,7 @@ int main(int argc, char **argv) {
     const double diameter = 10;
 
     test_assert_true(well_branch_collection_is_instance(branches));
-    test_assert_int_equal(well_branch_collection_get_size(branches), 0);
-    test_assert_NULL(
-        well_branch_collection_iget_start_segment(branches, 0).get());
+    test_assert_size_t_equal(well_branch_collection_get_size(branches), 0);
     test_assert_NULL(
         well_branch_collection_get_start_segment(branches, 0).get());
     test_assert_false(well_branch_collection_has_branch(branches, 0));
@@ -38,7 +36,7 @@ int main(int argc, char **argv) {
         test_assert_true(
             well_branch_collection_add_start_segment(branches, segment2));
 
-        test_assert_int_equal(well_branch_collection_get_size(branches), 1);
+        test_assert_size_t_equal(well_branch_collection_get_size(branches), 1);
         test_assert_true(well_branch_collection_has_branch(branches, 78));
     }
     well_branch_collection_free(branches);

--- a/lib/resdata/tests/well_state_load.cpp
+++ b/lib/resdata/tests/well_state_load.cpp
@@ -55,13 +55,13 @@ int main(int argc, char **argv) {
                 test_assert_true(rst_file->has_kw(ISEG_KW));
                 test_assert_int_not_equal(
                     well_segment_collection_get_size(segments), 0);
-                test_assert_int_not_equal(
+                test_assert_size_t_not_equal(
                     well_branch_collection_get_size(branches), 0);
             } else {
                 test_assert_int_equal(
                     well_segment_collection_get_size(segments), 0);
-                test_assert_int_equal(well_branch_collection_get_size(branches),
-                                      0);
+                test_assert_size_t_equal(
+                    well_branch_collection_get_size(branches), 0);
                 test_assert_false(well_state.is_MSW());
             }
         }

--- a/lib/resdata/well_branch_collection.cpp
+++ b/lib/resdata/well_branch_collection.cpp
@@ -1,6 +1,7 @@
 
+#include <cstddef>
 #include <memory>
-#include <vector>
+#include <unordered_map>
 
 #include <ert/util/type_macros.hpp>
 
@@ -14,8 +15,7 @@
 struct well_branch_collection_struct {
     UTIL_TYPE_ID_DECLARATION;
 
-    std::vector<std::shared_ptr<WellSegment>> __start_segments;
-    std::vector<int> index_map;
+    std::unordered_map<int, std::shared_ptr<WellSegment>> start_segments;
 };
 
 UTIL_IS_INSTANCE_FUNCTION(well_branch_collection,
@@ -28,52 +28,26 @@ well_branch_collection_type *well_branch_collection_alloc() {
     return branch_collection;
 }
 
-namespace {
-
-int well_branch_collection_safe_iget_index(
-    const well_branch_collection_type *branches, int index) {
-    if (index >= (int)branches->index_map.size())
-        return -1;
-    else
-        return branches->index_map[index];
-}
-
-} // namespace
-
 void well_branch_collection_free(well_branch_collection_type *branches) {
     delete branches;
 }
 
-int well_branch_collection_get_size(
-    const well_branch_collection_type *branches) {
-    return branches->__start_segments.size();
+size_t
+well_branch_collection_get_size(const well_branch_collection_type *branches) {
+    return branches->start_segments.size();
 }
 
 bool well_branch_collection_has_branch(
     const well_branch_collection_type *branches, int branch_id) {
-    if (well_branch_collection_safe_iget_index(branches, branch_id) >= 0)
-        return true;
-    else
-        return false;
-}
-
-const std::shared_ptr<WellSegment> well_branch_collection_iget_start_segment(
-    const well_branch_collection_type *branches, int index) {
-    if (index < static_cast<int>(branches->__start_segments.size()))
-        return branches->__start_segments[index];
-    else
-        return {nullptr};
+    return branches->start_segments.count(branch_id) > 0;
 }
 
 const std::shared_ptr<WellSegment> well_branch_collection_get_start_segment(
     const well_branch_collection_type *branches, int branch_id) {
-    int internal_index =
-        well_branch_collection_safe_iget_index(branches, branch_id);
-    if (internal_index >= 0)
-        return well_branch_collection_iget_start_segment(branches,
-                                                         internal_index);
-    else
+    auto iter = branches->start_segments.find(branch_id);
+    if (iter == branches->start_segments.end())
         return {nullptr};
+    return iter->second;
 }
 
 bool well_branch_collection_add_start_segment(
@@ -81,19 +55,8 @@ bool well_branch_collection_add_start_segment(
     std::shared_ptr<WellSegment> start_segment) {
     if ((start_segment->get_link_count() == 0) &&
         (start_segment->get_outlet())) {
-        int branch_id = start_segment->get_branch_id();
-        int current_index =
-            well_branch_collection_safe_iget_index(branches, branch_id);
-        if (current_index >= 0)
-            branches->__start_segments[current_index] = start_segment;
-        else {
-            int new_index = branches->__start_segments.size();
-            branches->__start_segments.push_back(start_segment);
-            if (branch_id >= (int)branches->index_map.size())
-                branches->index_map.resize(branch_id + 1, -1);
-            branches->index_map[branch_id] = new_index;
-        }
-
+        branches->start_segments[start_segment->get_branch_id()] =
+            start_segment;
         return true;
     } else
         return false;

--- a/lib/tests/test_layer.cpp
+++ b/lib/tests/test_layer.cpp
@@ -307,29 +307,21 @@ TEST_CASE("Layer getters and setters", "[layer]") {
             }
 
             AND_WHEN("Tracing block content") {
-                auto i_list = make_int_vector(0, 0);
-                auto j_list = make_int_vector(0, 0);
-
                 AND_WHEN("Tracing block content without erasing") {
-                    bool traced =
-                        layer_trace_block_content(layer.get(), false, 3, 3, 42,
-                                                  i_list.get(), j_list.get());
+                    auto indices =
+                        layer_trace_block_content(layer.get(), false, 3, 3, 42);
 
                     THEN("All 9 cells are found") {
-                        REQUIRE(traced);
-                        REQUIRE(int_vector_size(i_list.get()) == 9);
-                        REQUIRE(int_vector_size(j_list.get()) == 9);
+                        REQUIRE(indices.size() == 9);
                     }
                 }
 
                 AND_WHEN("Tracing and erasing block content") {
-                    bool traced =
-                        layer_trace_block_content(layer.get(), true, 3, 3, 42,
-                                                  i_list.get(), j_list.get());
+                    auto indices =
+                        layer_trace_block_content(layer.get(), true, 3, 3, 42);
 
                     THEN("Cells are found and erased") {
-                        REQUIRE(traced);
-                        REQUIRE(int_vector_size(i_list.get()) == 9);
+                        REQUIRE(indices.size() == 9);
 
                         for (int i = 2; i < 5; i++) {
                             for (int j = 2; j < 5; j++) {
@@ -341,20 +333,18 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                 }
 
                 THEN("Tracing with value 0 from nonz-zero cell value traces") {
-                    REQUIRE(layer_trace_block_content(layer.get(), false, 3, 3,
-                                                      0, i_list.get(),
-                                                      j_list.get()));
-                    REQUIRE(int_vector_size(i_list.get()) == 9);
-                    REQUIRE(int_vector_size(j_list.get()) == 9);
+                    auto indices =
+                        layer_trace_block_content(layer.get(), false, 3, 3, 0);
+                    REQUIRE(indices.size() == 9);
                 }
 
                 THEN("Tracing from a cell with non-matching value fails") {
-                    REQUIRE_FALSE(
-                        layer_trace_block_content(layer.get(), false, 6, 6, 0,
-                                                  i_list.get(), j_list.get()));
-                    REQUIRE_FALSE(
-                        layer_trace_block_content(layer.get(), false, 5, 5, 99,
-                                                  i_list.get(), j_list.get()));
+                    REQUIRE(
+                        layer_trace_block_content(layer.get(), false, 6, 6, 0)
+                            .empty());
+                    REQUIRE(
+                        layer_trace_block_content(layer.get(), false, 5, 5, 99)
+                            .empty());
                 }
             }
 

--- a/lib/tests/test_layer.cpp
+++ b/lib/tests/test_layer.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <tuple>
 #include <memory>
+#include <set>
 
 using namespace Catch;
 using namespace Matchers;
@@ -359,10 +360,10 @@ TEST_CASE("Layer getters and setters", "[layer]") {
 
             AND_WHEN("Tracing edges") {
                 std::vector<int_point2d_type> corner_list;
-                auto cell_list = make_int_vector(0, 0);
+                std::vector<int> cell_list;
                 THEN("The 3x3 block is traced when value is 42") {
-                    REQUIRE(layer_trace_block_edge(
-                        layer.get(), 2, 2, 42, corner_list, cell_list.get()));
+                    REQUIRE(layer_trace_block_edge(layer.get(), 2, 2, 42,
+                                                   corner_list, cell_list));
                     REQUIRE(corner_list ==
                             std::vector<int_point2d_type>{{2, 2},
                                                           {3, 2},
@@ -386,18 +387,19 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                     //           i
 
                     AND_THEN("The outside cells are traced") {
-                        REQUIRE(int_vector_size(cell_list.get()) == 8);
+                        REQUIRE(std::set(cell_list.begin(), cell_list.end())
+                                    .size() == 8);
                     }
                 }
 
                 THEN("Tracing non-existent value returns false") {
                     REQUIRE_FALSE(layer_trace_block_edge(
-                        layer.get(), 2, 2, 99, corner_list, cell_list.get()));
+                        layer.get(), 2, 2, 99, corner_list, cell_list));
                 }
 
                 THEN("Tracing from cell with value 0 returns false") {
                     REQUIRE_FALSE(layer_trace_block_edge(
-                        layer.get(), 0, 0, 42, corner_list, cell_list.get()));
+                        layer.get(), 0, 0, 42, corner_list, cell_list));
                 }
                 THEN("Tracing from any cell traces the shape") {
                     for (int i = 2; i < 5; i++) {
@@ -405,8 +407,10 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                             if (i != 3 || j != 3) {
                                 REQUIRE(layer_trace_block_edge(
                                     layer.get(), i, j, 42, corner_list,
-                                    cell_list.get()));
-                                REQUIRE(int_vector_size(cell_list.get()) == 8);
+                                    cell_list));
+                                REQUIRE(
+                                    std::set(cell_list.begin(), cell_list.end())
+                                        .size() == 8);
                             }
                         }
                     }
@@ -416,16 +420,18 @@ TEST_CASE("Layer getters and setters", "[layer]") {
 
         WHEN("Tracing edges") {
             std::vector<int_point2d_type> corner_list;
-            auto cell_list = make_int_vector(0, 0);
+            std::vector<int> cell_list;
 
             GIVEN("A single non-zero cell block") {
                 layer_iset_cell_value(layer.get(), 5, 5, 7);
                 THEN("single cell block is traced") {
-                    REQUIRE(layer_trace_block_edge(
-                        layer.get(), 5, 5, 7, corner_list, cell_list.get()));
+                    REQUIRE(layer_trace_block_edge(layer.get(), 5, 5, 7,
+                                                   corner_list, cell_list));
                     REQUIRE(corner_list == std::vector<int_point2d_type>{
                                                {5, 5}, {6, 5}, {6, 6}, {5, 6}});
-                    REQUIRE(int_vector_size(cell_list.get()) == 1);
+                    REQUIRE(
+                        std::set(cell_list.begin(), cell_list.end()).size() ==
+                        1);
                 }
             }
             AND_GIVEN("A 3x3 block starting at (0,0)") {
@@ -436,8 +442,8 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                 }
 
                 THEN("Starting from (0,0) traces the block") {
-                    REQUIRE(layer_trace_block_edge(
-                        layer.get(), 0, 0, 10, corner_list, cell_list.get()));
+                    REQUIRE(layer_trace_block_edge(layer.get(), 0, 0, 10,
+                                                   corner_list, cell_list));
                     REQUIRE(corner_list ==
                             std::vector<int_point2d_type>{{0, 0},
                                                           {1, 0},
@@ -451,7 +457,9 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                                                           {0, 3},
                                                           {0, 2},
                                                           {0, 1}});
-                    REQUIRE(int_vector_size(cell_list.get()) == 8);
+                    REQUIRE(
+                        std::set(cell_list.begin(), cell_list.end()).size() ==
+                        8);
                 }
             }
 
@@ -464,8 +472,7 @@ TEST_CASE("Layer getters and setters", "[layer]") {
 
                 THEN("Starting from (nx-1,ny-1) traces the block") {
                     REQUIRE(layer_trace_block_edge(layer.get(), nx - 1, ny - 1,
-                                                   20, corner_list,
-                                                   cell_list.get()));
+                                                   20, corner_list, cell_list));
                     REQUIRE(corner_list ==
                             std::vector<int_point2d_type>{{10, 7},
                                                           {10, 8},
@@ -479,7 +486,9 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                                                           {9, 5},
                                                           {10, 5},
                                                           {10, 6}});
-                    REQUIRE(int_vector_size(cell_list.get()) == 8);
+                    REQUIRE(
+                        std::set(cell_list.begin(), cell_list.end()).size() ==
+                        8);
                 }
             }
             AND_GIVEN("An L-shaped block") {
@@ -490,9 +499,11 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                 layer_iset_cell_value(layer.get(), 3, 5, 15);
 
                 THEN("the L-shaped edge is traced") {
-                    REQUIRE(layer_trace_block_edge(
-                        layer.get(), 3, 3, 15, corner_list, cell_list.get()));
-                    REQUIRE(int_vector_size(cell_list.get()) == 5);
+                    REQUIRE(layer_trace_block_edge(layer.get(), 3, 3, 15,
+                                                   corner_list, cell_list));
+                    REQUIRE(
+                        std::set(cell_list.begin(), cell_list.end()).size() ==
+                        5);
                     REQUIRE(corner_list ==
                             std::vector<int_point2d_type>{{3, 3},
                                                           {4, 3},
@@ -517,8 +528,8 @@ TEST_CASE("Layer getters and setters", "[layer]") {
 
                 THEN("Tracing from a starting point not on edge traces the "
                      "pattern") {
-                    REQUIRE(layer_trace_block_edge(
-                        layer.get(), 6, 6, 50, corner_list, cell_list.get()));
+                    REQUIRE(layer_trace_block_edge(layer.get(), 6, 6, 50,
+                                                   corner_list, cell_list));
                     REQUIRE(corner_list ==
                             std::vector<int_point2d_type>{{8, 6},
                                                           {8, 7},
@@ -532,7 +543,9 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                                                           {6, 5},
                                                           {7, 5},
                                                           {8, 5}});
-                    REQUIRE(int_vector_size(cell_list.get()) == 8);
+                    REQUIRE(
+                        std::set(cell_list.begin(), cell_list.end()).size() ==
+                        8);
                 }
             }
             AND_GIVEN("Block with concave shape") {
@@ -545,8 +558,8 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                 }
 
                 THEN("The shape is traced") {
-                    REQUIRE(layer_trace_block_edge(
-                        layer.get(), 0, 0, 60, corner_list, cell_list.get()));
+                    REQUIRE(layer_trace_block_edge(layer.get(), 0, 0, 60,
+                                                   corner_list, cell_list));
                     REQUIRE(corner_list ==
                             std::vector<int_point2d_type>{
                                 {0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {5, 0},
@@ -554,7 +567,9 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                                 {5, 1}, {4, 1}, {3, 1}, {2, 1}, {1, 1}, {1, 2},
                                 {1, 3}, {1, 4}, {1, 5}, {1, 6}, {0, 6}, {0, 5},
                                 {0, 4}, {0, 3}, {0, 2}, {0, 1}});
-                    REQUIRE(int_vector_size(cell_list.get()) == 13);
+                    REQUIRE(
+                        std::set(cell_list.begin(), cell_list.end()).size() ==
+                        13);
                 }
             }
             AND_GIVEN("A block with stair-step pattern") {
@@ -565,8 +580,8 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                 layer_iset_cell_value(layer.get(), 2, 2, 70);
 
                 THEN("The stair-step shape is traced") {
-                    REQUIRE(layer_trace_block_edge(
-                        layer.get(), 0, 0, 70, corner_list, cell_list.get()));
+                    REQUIRE(layer_trace_block_edge(layer.get(), 0, 0, 70,
+                                                   corner_list, cell_list));
                     REQUIRE(corner_list ==
                             std::vector<int_point2d_type>{{0, 0},
                                                           {1, 0},
@@ -580,7 +595,9 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                                                           {1, 2},
                                                           {1, 1},
                                                           {0, 1}});
-                    REQUIRE(int_vector_size(cell_list.get()) == 5);
+                    REQUIRE(
+                        std::set(cell_list.begin(), cell_list.end()).size() ==
+                        5);
                 }
             }
             AND_GIVEN("A block with zigzag pattern") {
@@ -592,8 +609,8 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                 layer_iset_cell_value(layer.get(), 1, 2, 80);
 
                 THEN("The zigzag shape is traced") {
-                    REQUIRE(layer_trace_block_edge(
-                        layer.get(), 0, 0, 80, corner_list, cell_list.get()));
+                    REQUIRE(layer_trace_block_edge(layer.get(), 0, 0, 80,
+                                                   corner_list, cell_list));
                     REQUIRE(corner_list ==
                             std::vector<int_point2d_type>{{0, 0},
                                                           {1, 0},
@@ -605,7 +622,9 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                                                           {0, 3},
                                                           {0, 2},
                                                           {0, 1}});
-                    REQUIRE(int_vector_size(cell_list.get()) == 6);
+                    REQUIRE(
+                        std::set(cell_list.begin(), cell_list.end()).size() ==
+                        6);
                 }
             }
             GIVEN("A block with T-shaped pattern") {
@@ -617,15 +636,17 @@ TEST_CASE("Layer getters and setters", "[layer]") {
                 }
 
                 THEN("The shape is traced") {
-                    REQUIRE(layer_trace_block_edge(
-                        layer.get(), 2, 2, 90, corner_list, cell_list.get()));
+                    REQUIRE(layer_trace_block_edge(layer.get(), 2, 2, 90,
+                                                   corner_list, cell_list));
                     REQUIRE(corner_list == std::vector<int_point2d_type>{
                                                {2, 2}, {3, 2}, {4, 2}, {5, 2},
                                                {5, 3}, {4, 3}, {3, 3}, {3, 4},
                                                {3, 5}, {3, 6}, {3, 7}, {2, 7},
                                                {2, 6}, {2, 5}, {2, 4}, {2, 3},
                                                {1, 3}, {0, 3}, {0, 2}, {1, 2}});
-                    REQUIRE(int_vector_size(cell_list.get()) == 9);
+                    REQUIRE(
+                        std::set(cell_list.begin(), cell_list.end()).size() ==
+                        9);
                 }
             }
         }

--- a/lib/util/parser.cpp
+++ b/lib/util/parser.cpp
@@ -4,6 +4,8 @@
 #include <cctype>
 #include <cstdlib>
 
+#include <string_view>
+
 #include <ert/util/util.hpp>
 #include <ert/util/parser.hpp>
 #include <ert/util/stringlist.hpp>
@@ -152,8 +154,13 @@ static bool is_special(const char c, const basic_parser_type *parser) {
     return in_set(c, parser->specials);
 }
 
-static bool is_in_quoters(const char c, const basic_parser_type *parser) {
-    return in_set(c, parser->quoters);
+/* Takes an int so that an EOF returned by fgetc() can be passed in without
+   being aliased onto the legitimate byte 0xFF. Characters read from a buffer
+   must be passed as unsigned char for the same reason. */
+static bool is_in_quoters(int c, const basic_parser_type *parser) {
+    if (c == EOF)
+        return false;
+    return in_set(static_cast<char>(c), parser->quoters);
 }
 
 static bool is_in_delete_set(const char c, const basic_parser_type *parser) {
@@ -291,7 +298,7 @@ static int length_of_normal_non_splitters(const char *buffer,
             at_end = true;
             continue;
         }
-        if (is_in_quoters(current, parser)) {
+        if (is_in_quoters(static_cast<unsigned char>(current), parser)) {
             at_end = true;
             continue;
         }
@@ -375,7 +382,8 @@ stringlist_type *basic_parser_tokenize_buffer(const basic_parser_type *parser,
         /**
        If the character is a quotation start, we copy the whole quotation.
     */
-        if (is_in_quoters(buffer[position], parser)) {
+        if (is_in_quoters(static_cast<unsigned char>(buffer[position]),
+                          parser)) {
             int length = length_of_quotation(&buffer[position]);
             char *token = alloc_quoted_token(&buffer[position], length,
                                              strip_quote_marks);
@@ -439,7 +447,7 @@ stringlist_type *basic_parser_tokenize_buffer(const basic_parser_type *parser,
     return tokens;
 }
 
-static bool fseek_quote_end(char quoter, FILE *stream) {
+static bool fseek_quote_end(int quoter, FILE *stream) {
     int c;
     do {
         c = fgetc(stream);
@@ -449,27 +457,6 @@ static bool fseek_quote_end(char quoter, FILE *stream) {
         return true;
     else
         return false;
-}
-
-static bool fgetc_while_equal(FILE *stream, const char *string,
-                              bool case_sensitive) {
-    bool equal = true;
-    long int current_pos = util_ftell(stream);
-    size_t string_index;
-    for (string_index = 0; string_index < strlen(string); string_index++) {
-        int c = fgetc(stream);
-        if (!case_sensitive)
-            c = toupper(c);
-
-        if (c != string[string_index]) {
-            equal = false;
-            break;
-        }
-    }
-
-    if (!equal) /* OK - not equal - go back. */
-        util_fseek(stream, current_pos, SEEK_SET);
-    return equal;
 }
 
 /**
@@ -483,102 +470,99 @@ static bool fgetc_while_equal(FILE *stream, const char *string,
 */
 
 bool basic_parser_fseek_string(const basic_parser_type *parser, FILE *stream,
-                               const char *__string, bool skip_string,
+                               std::string_view string, bool skip_string,
                                bool case_sensitive) {
     bool string_found = false;
-    char *string = util_alloc_string_copy(__string);
-    if (!case_sensitive)
-        util_strupr(string);
-    {
-        long int initial_pos =
-            util_ftell(stream); /* Store the inital position. */
-        bool cont = true;
+    offset_type initial_pos =
+        util_ftell(stream); /* Store the inital position. */
+    bool cont = true;
 
-        if (strstr(string, parser->comment_start) != NULL)
-            util_abort("%s: sorry the string contains a comment start - will "
-                       "never find it ... \n",
-                       __func__); /* A bit harsh ?? */
+    if (string.find(parser->comment_start) != std::string_view::npos)
+        util_abort("%s: sorry the string contains a comment start - will "
+                   "never find it ... \n",
+                   __func__); /* A bit harsh ?? */
 
-        do {
-            int c = fgetc(stream);
-            if (!case_sensitive)
-                c = toupper(c);
+    /* An empty string matches at the first position
+       after any leading quotation or comment has been skipped. */
+    const bool empty_string = string.empty();
+    int string_start = EOF;
+    std::string_view string_rest = "";
+    if (!empty_string) {
+        string_start = static_cast<unsigned char>(string[0]);
+        if (!case_sensitive)
+            string_start = std::toupper(string_start);
+        string_rest = string.substr(1);
+    }
 
-            /* Special treatment of quoters - does not properly handle escaping of the quoters. */
-            if (is_in_quoters(c, parser)) {
-                long int quote_start_pos = util_ftell(stream);
-                if (!fseek_quote_end(c, stream)) {
-                    util_fseek(stream, quote_start_pos, SEEK_SET);
+    offset_type before_string = initial_pos;
+    do {
+        before_string = util_ftell(stream);
+        int c = fgetc(stream);
+        if (!case_sensitive && c != EOF)
+            c = std::toupper(c);
+
+        /* Special treatment of quoters - does not properly handle escaping of the quoters. */
+        if (is_in_quoters(c, parser)) {
+            offset_type quote_start_pos = util_ftell(stream);
+            if (!fseek_quote_end(c, stream)) {
+                util_fseek(stream, quote_start_pos, SEEK_SET);
+                fprintf(stderr,
+                        "Warning: unterminated quotation starting at line: "
+                        "%d \n",
+                        util_get_current_linenr(stream));
+                util_fseek(stream, 0, SEEK_END);
+            }
+            /* Now we are either at the first character following a
+               terminated quotation, or at EOF. */
+            continue;
+        }
+
+        /* Special treatment of comments: */
+        if (c != EOF &&
+            c == static_cast<unsigned char>(parser->comment_start[0])) {
+            /* this might be the start of a comment - let us check further. */
+            bool comment_start = util_fgetc_while_equal(
+                stream, &parser->comment_start[1], false);
+            if (comment_start) {
+                offset_type comment_start_pos =
+                    util_ftell(stream) -
+                    static_cast<offset_type>(strlen(parser->comment_start));
+                /* Start seeking for comment_end */
+                if (!util_fseek_string(stream, parser->comment_end, true,
+                                       true)) {
+                    /* No end comment end was found - what to do about that??
+                       The file is just positioned at the end - and the routine
+                       will exit at the next step - with a Warning. */
+                    util_fseek(stream, comment_start_pos, SEEK_SET);
                     fprintf(stderr,
-                            "Warning: unterminated quotation starting at line: "
-                            "%d \n",
+                            "Warning: unterminated comment starting at "
+                            "line: %d \n",
                             util_get_current_linenr(stream));
                     util_fseek(stream, 0, SEEK_END);
                 }
-                /*
-           Now we are either at the first character following a
-           terminated quotation, or at EOF.
-        */
                 continue;
+                /* Now we are at the character following a comment end - or at EOF. */
             }
+        }
 
-            /* Special treatment of comments: */
-            if (c == parser->comment_start[0]) {
-                /* OK - this might be the start of a comment - let us check further. */
-                bool comment_start =
-                    fgetc_while_equal(stream, &parser->comment_start[1], false);
-                if (comment_start) {
-                    long int comment_start_pos =
-                        util_ftell(stream) - strlen(parser->comment_start);
-                    /* Start seeking for comment_end */
-                    if (!util_fseek_string(stream, parser->comment_end, true,
-                                           true)) {
-                        /*
-               No end comment end was found - what to do about that??
-               The file is just positioned at the end - and the routine
-               will exit at the next step - with a Warning.
-            */
-                        util_fseek(stream, comment_start_pos, SEEK_SET);
-                        fprintf(stderr,
-                                "Warning: unterminated comment starting at "
-                                "line: %d \n",
-                                util_get_current_linenr(stream));
-                        util_fseek(stream, 0, SEEK_END);
-                    }
-                    continue;
-                    /* Now we are at the character following a comment end - or at EOF. */
-                }
-            }
-
-            /* Now c is a regular character - and we can start looking for our string. */
-            if (c ==
-                string
-                    [0]) { /* OK - we got the first character right - lets try in more detail: */
-                bool equal =
-                    fgetc_while_equal(stream, &string[1], case_sensitive);
-                if (equal) {
-                    string_found = true;
-                    cont = false;
-                }
-            }
-
-            if (c == EOF)
+        /* Now c is a regular character - and we can start looking for our string. */
+        if (empty_string || c == string_start) {
+            /* we got the first character right - lets try in more detail: */
+            if (util_fgetc_while_equal(stream, string_rest, case_sensitive)) {
+                string_found = true;
                 cont = false;
-
-        } while (cont);
-
-        if (string_found) {
-            if (!skip_string) {
-                offset_type offset = (offset_type)strlen(string);
-                util_fseek(
-                    stream, -offset,
-                    SEEK_CUR); /* Reposition to the beginning of 'string' */
             }
-        } else
-            util_fseek(
-                stream, initial_pos,
-                SEEK_SET); /* Could not find the string reposition at initial position. */
-    }
-    free(string);
+        }
+        if (c == EOF)
+            cont = false;
+    } while (cont);
+
+    if (string_found) {
+        /* empty string always means position before c, same
+           for skip_string=false */
+        if (!skip_string || empty_string)
+            util_fseek(stream, before_string, SEEK_SET);
+    } else /* Could not find the string: reposition at initial position. */
+        util_fseek(stream, initial_pos, SEEK_SET);
     return string_found;
 }

--- a/lib/util/test_work_area.cpp
+++ b/lib/util/test_work_area.cpp
@@ -1,3 +1,13 @@
+#include <ctime>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include <system_error>
+#include <filesystem>
+#include <random>
+
 #include <ert/util/ert_api_config.hpp>
 
 #ifdef ERT_HAVE_GETUID
@@ -6,12 +16,6 @@
 #include <pwd.h>
 #include <paths.h>
 #endif
-
-#include <cstdlib>
-#include <cstdio>
-#include <cstring>
-
-#include <filesystem>
 
 #include <ert/util/util.hpp>
 #include <ert/util/test_work_area.hpp>
@@ -130,13 +134,13 @@ static bool test_work_area_copy_parent__(const TestArea *work_area,
         return false;
     }
 }
+static std::mt19937 generator(std::random_device{}());
 
 static char *create_test_path(const std::string &test_name, const char *prefix,
                               const char *user_name) {
     const int MAX_TRIES = 10;
     for (int try_count = 0; try_count < MAX_TRIES; try_count++) {
-        unsigned int random_int;
-        util_fread_dev_urandom(sizeof random_int, (char *)&random_int);
+        unsigned int random_int = static_cast<unsigned int>(generator());
         random_int = random_int % 100000000;
 
         char *test_path = util_alloc_sprintf(TEST_PATH_FMT, user_name,

--- a/lib/util/util.cpp
+++ b/lib/util/util.cpp
@@ -25,11 +25,13 @@
 #include "ert/util/build_config.hpp"
 
 #include <cerrno>
+#include <system_error>
 
 #include <cstdint>
 #include <cctype>
 #include <cstdlib>
 #include <csignal>
+#include <string_view>
 #include <sys/stat.h>
 
 #ifdef HAVE_FNMATCH
@@ -295,16 +297,49 @@ char *util_alloc_substring_copy(const char *src, int offset, int N_) {
     return copy;
 }
 
-void util_strupr(char *s) {
-    size_t i;
-    for (i = 0; i < strlen(s); i++)
-        s[i] = toupper(s[i]);
-}
+bool util_fgetc_while_equal(FILE *stream, std::string_view str,
+                            bool case_sensitive) {
+    if (str.empty())
+        return true;
+    if (!stream) {
+        return false;
+    }
+    offset_type current_pos = util_ftell(stream);
+    if (current_pos == (offset_type)-1) {
+        return false;
+    }
 
-char *util_alloc_strupr_copy(const char *s) {
-    char *c = util_alloc_string_copy(s);
-    util_strupr(c);
-    return c;
+    bool equal = true;
+    for (size_t string_index = 0; string_index < str.length(); ++string_index) {
+        int c = std::fgetc(stream);
+
+        if (c == EOF) {
+            equal = false;
+            break;
+        }
+
+        unsigned char target_char =
+            static_cast<unsigned char>(str[string_index]);
+        unsigned char stream_char = static_cast<unsigned char>(c);
+
+        if (!case_sensitive) {
+            stream_char = static_cast<unsigned char>(std::toupper(stream_char));
+            target_char = static_cast<unsigned char>(std::toupper(target_char));
+        }
+        if (stream_char != target_char) {
+            equal = false;
+            break;
+        }
+    }
+
+    if (!equal) { /* not equal - go back. */
+        if (util_fseek(stream, current_pos, SEEK_SET) != 0)
+            throw std::system_error(errno, std::generic_category(),
+                                    "util_fgetc_while_equal: Failed to seek "
+                                    "back");
+    }
+
+    return equal;
 }
 
 /**
@@ -321,63 +356,44 @@ char *util_alloc_strupr_copy(const char *s) {
    case, otherwise we accept any case combination.
 */
 
-bool util_fseek_string(FILE *stream, const char *__string, bool skip_string,
+bool util_fseek_string(FILE *stream, std::string_view string, bool skip_string,
                        bool case_sensitive) {
+    /* Searching for the empty string succeeds immediately, without moving the
+       stream position. */
+    if (string.empty())
+        return true;
+
     bool string_found = false;
-    char *string = util_alloc_string_copy(__string);
-
+    int string_start = static_cast<unsigned char>(string[0]);
     if (!case_sensitive)
-        util_strupr(string);
-    {
-        int len = strlen(string);
-        long int initial_pos =
-            util_ftell(stream); /* Store the inital position. */
-        bool cont = true;
-        do {
-            int c = fgetc(stream);
-            if (!case_sensitive)
-                c = toupper(c);
+        string_start = std::toupper(string_start);
+    std::string_view string_rest = string.substr(1);
 
-            if (c ==
-                string
-                    [0]) { /* OK - we got the first character right - lets try in more detail: */
-                long int current_pos = util_ftell(stream);
-                bool equal = true;
-                int string_index;
-                for (string_index = 1; string_index < len; string_index++) {
-                    c = fgetc(stream);
-                    if (!case_sensitive)
-                        c = toupper(c);
+    offset_type initial_pos =
+        util_ftell(stream); /* Store the inital position. */
+    int c;
+    do {
+        c = fgetc(stream);
+        if (!case_sensitive && c != EOF)
+            c = std::toupper(c);
 
-                    if (c != string[string_index]) {
-                        equal = false;
-                        break;
-                    }
-                }
+        if (c == string_start) {
+            /* we got the first character right - lets try in more detail: */
+            string_found =
+                util_fgetc_while_equal(stream, string_rest, case_sensitive);
+        }
+    } while (c != EOF && !string_found);
 
-                if (equal) {
-                    string_found = true;
-                    cont = false;
-                } else /* Go back to current pos and continue searching. */
-                    util_fseek(stream, current_pos, SEEK_SET);
-            }
-            if (c == EOF)
-                cont = false;
-        } while (cont);
-
-        if (string_found) {
-            if (!skip_string) {
-                offset_type offset = (offset_type)strlen(string);
-                util_fseek(
-                    stream, -offset,
-                    SEEK_CUR); /* Reposition to the beginning of 'string' */
-            }
-        } else
-            util_fseek(
-                stream, initial_pos,
-                SEEK_SET); /* Could not find the string reposition at initial position. */
-    }
-    free(string);
+    if (string_found) {
+        if (!skip_string) {
+            offset_type offset = (offset_type)string.size();
+            util_fseek(stream, -offset,
+                       SEEK_CUR); /* Reposition to the beginning of 'string' */
+        }
+    } else
+        util_fseek(
+            stream, initial_pos,
+            SEEK_SET); /* Could not find the string reposition at initial position. */
     return string_found;
 }
 

--- a/lib/util/util.cpp
+++ b/lib/util/util.cpp
@@ -204,16 +204,6 @@ static bool EOL_CHAR(char c) {
         return false;
 }
 
-void util_fread_dev_urandom(int buffer_size_, char *buffer) {
-    size_t buffer_size = buffer_size_;
-    FILE *stream = util_fopen("/dev/urandom", "r");
-    if (fread(buffer, 1, buffer_size, stream) != buffer_size)
-        util_abort("%s: failed to read:%d bytes from /dev/random \n", __func__,
-                   buffer_size);
-
-    fclose(stream);
-}
-
 /**
    Kahan summation is a technique to retain numerical precision when
    summing a long vector of values. See:

--- a/tests/rd_tests/test_rd_sum.py
+++ b/tests/rd_tests/test_rd_sum.py
@@ -557,6 +557,87 @@ def test_summary_sim_length():
 
 
 @pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize("lazy_load", [True, False])
+@pytest.mark.parametrize(
+    "time_units, expected_dates",
+    [
+        pytest.param(
+            "DAYS",
+            [
+                datetime.datetime(2010, 1, 1),
+                datetime.datetime(2010, 1, 25),
+                datetime.datetime(2010, 2, 18),
+            ],
+            id="days",
+        ),
+        pytest.param(
+            "HOURS",
+            [
+                datetime.datetime(2010, 1, 1),
+                datetime.datetime(2010, 1, 2),
+                datetime.datetime(2010, 1, 3),
+            ],
+            id="hours",
+        ),
+    ],
+)
+def test_that_the_time_vector_is_scaled_by_the_unit_of_the_time_keyword(
+    lazy_load, time_units, expected_dates
+):
+    """
+    The same raw TIME values mean different things depending on the unit of
+    the TIME keyword, so the dates must differ while sim_length, which is
+    reported in those same units, must not. Lazy and eager loading derive the
+    dates through separate code paths, so both are checked.
+    """
+    create_summary(
+        summary_keys=("FOPR",),
+        time_units=time_units,
+        times=(0.0, 24.0, 48.0),
+        start_date=Date(day=1, month=1, year=2010, hour=0, minutes=0, micro_seconds=0),
+    )
+
+    summary = Summary("TEST", lazy_load=lazy_load)
+    assert summary.dates == expected_dates
+    assert summary.sim_length == pytest.approx(48.0)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize("lazy_load", [True, False])
+def test_that_an_unrecognized_time_unit_is_rejected(lazy_load):
+    """Only DAYS and HOURS can be scaled to seconds; YEARS is not supported."""
+    create_summary(summary_keys=("FOPR",), time_units="YEARS")
+
+    with pytest.raises(ValueError, match=r"time_unit:YEARS.*not recognized"):
+        Summary("TEST", lazy_load=lazy_load)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_resampling_an_hourly_case_keeps_the_time_vector_in_hours():
+    """
+    The resampled case is written with a freshly built SMSPEC, and it should
+    inherit the time unit of the case it was resampled from rather than
+    silently switching to days.
+    """
+    create_summary(
+        summary_keys=("FOPR",),
+        time_units="HOURS",
+        times=(0.0, 24.0, 48.0),
+        start_date=Date(day=1, month=1, year=2010, hour=0, minutes=0, micro_seconds=0),
+    )
+
+    time_points = [
+        datetime.datetime(2010, 1, 1),
+        datetime.datetime(2010, 1, 2),
+        datetime.datetime(2010, 1, 3),
+    ]
+    resampled = Summary("TEST").resample("RESAMPLED", time_points)
+
+    assert resampled.dates == time_points
+    assert resampled.sim_length == pytest.approx(48.0)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
 def test_summary_iget_date():
     create_summary(summary_keys=("FOPR",), times=(0.0, 1.0, 2.0))
 
@@ -2265,6 +2346,16 @@ def test_that_solve_days_precision_is_unaffected_by_start_date(start_date):
     assert list(summary.solve_days("FOPT", 2.9999999999999996)) == pytest.approx(
         [0.9999999999999998], abs=0
     )
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+def test_that_add_t_step_rejects_negative_report_step():
+    start_date = datetime.datetime(2000, 1, 1)
+    writer = Summary.writer("NEGATIVE_REPORT_STEP", start_date, 5, 5, 5)
+    writer.add_variable("FOPT")
+
+    with pytest.raises(ValueError, match="report step cannot be negative"):
+        writer.add_t_step(-1, 1.0)
 
 
 @pytest.mark.usefixtures("use_tmpdir")

--- a/tests/rd_tests/test_sum.py
+++ b/tests/rd_tests/test_sum.py
@@ -915,68 +915,172 @@ def test_that_end_time_is_sim_start_when_there_are_no_steps():
     # sum.data_start will raise
 
 
+def _write_day_month_year_case(case, dates, values):
+    """Write a summary whose only time information is DAY/MONTH/YEAR.
+
+    The simulation start is taken from the first date, and a single FOPT
+    keyword carries `values`.
+    """
+    smspec = Smspec(
+        nx=2,
+        ny=2,
+        nz=2,
+        restarted_from_step=0,
+        num_keywords=4,
+        restart="        ",
+        keywords=["DAY     ", "MONTH   ", "YEAR    ", "FOPT    "],
+        well_names=[":+:+:+:+", ":+:+:+:+", ":+:+:+:+", "A_NAME  "],
+        region_numbers=[-32676, -32676, -32676, 0],
+        units=["        ", "        ", "        ", "SM3"],
+        start_date=Date(
+            day=dates[0].day,
+            month=dates[0].month,
+            year=dates[0].year,
+            hour=0,
+            minutes=0,
+            micro_seconds=0,
+        ),
+        intehead=SmspecIntehead(
+            unit=ResfoUnitSystem.METRIC,
+            simulator=Simulator.ECLIPSE_100,
+        ),
+    )
+    unsmry = Unsmry(
+        steps=[
+            SummaryStep(
+                seqnum=i,
+                ministeps=[
+                    SummaryMiniStep(
+                        mini_step=i,
+                        params=[
+                            float(date.day),
+                            float(date.month),
+                            float(date.year),
+                            value,
+                        ],
+                    )
+                ],
+            )
+            for i, (date, value) in enumerate(zip(dates, values))
+        ]
+    )
+    smspec.to_file(f"{case}.SMSPEC")
+    unsmry.to_file(f"{case}.UNSMRY")
+
+
 @pytest.mark.usefixtures("use_tmpdir")
-def test_that_a_summary_with_day_month_year_instead_of_time_is_read_correctly():
-    """
-    SummaryTStep derives the simulated time either from a TIME keyword
-    (given in DAYS/HOURS since simulation start) or, if that is absent,
-    from a set of DAY/MONTH/YEAR keywords
-    """
+@pytest.mark.parametrize("lazy_load", [True, False])
+def test_that_a_summary_with_day_month_year_instead_of_time_is_read_correctly(
+    lazy_load,
+):
     case = "DAY_MONTH_YEAR_CASE"
+    expected_dates = [
+        datetime.datetime(2010, 1, 1),
+        datetime.datetime(2010, 3, 15),
+    ]
+    expected_values = [10.0, 20.0]
+    _write_day_month_year_case(case, expected_dates, expected_values)
+
+    summary = Summary(case, lazy_load=lazy_load)
+    assert summary.dates == expected_dates
+    assert list(summary["FOPT"].values) == expected_values
+    assert summary.start_date == datetime.date(2010, 1, 1)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize("lazy_load", [True, False])
+def test_that_sim_length_of_a_day_month_year_summary_is_measured_in_days(lazy_load):
+    """
+    sim_length is the elapsed simulation time expressed in the unit of the
+    TIME keyword. A summary without a TIME keyword has no unit of its own, so
+    it is reported in days.
+    """
+    case = "DAY_MONTH_YEAR_LENGTH_CASE"
+    _write_day_month_year_case(
+        case,
+        [datetime.datetime(2010, 1, 1), datetime.datetime(2010, 3, 15)],
+        [10.0, 20.0],
+    )
+
+    summary = Summary(case, lazy_load=lazy_load)
+    assert summary.sim_length == pytest.approx(73.0)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize("lazy_load", [True, False])
+def test_that_a_timestep_cannot_be_added_to_a_day_month_year_summary(lazy_load):
+    case = "DAY_MONTH_YEAR_APPEND_CASE"
+    _write_day_month_year_case(case, [datetime.datetime(2010, 1, 1)], [10.0])
+
+    summary = Summary(case, lazy_load=lazy_load)
+    with pytest.raises(ValueError, match="without a TIME variable"):
+        summary.add_t_step(1, 10.0)
+
+
+@pytest.mark.usefixtures("use_tmpdir")
+@pytest.mark.parametrize("lazy_load", [True, False])
+@pytest.mark.parametrize(
+    "date_keywords",
+    [
+        pytest.param([], id="no_time_keywords"),
+        pytest.param(["DAY     ", "MONTH   "], id="day_and_month_but_no_year"),
+    ],
+)
+def test_that_a_summary_lacking_time_information_is_rejected(lazy_load, date_keywords):
+    """
+    Time information must come either from TIME or from a complete set of
+    DAY/MONTH/YEAR keywords. A partial set of date keywords is not usable,
+    so such a case must be rejected rather than silently read with a
+    wrong/default params index.
+    """
+    case = "NO_TIME_CASE"
     summary_keys = ["FOPT"]
-    start_date = Date(day=1, month=1, year=2010, hour=0, minutes=0, micro_seconds=0)
+    keywords = [*date_keywords, *summary_keys]
 
     smspec = Smspec(
         nx=2,
         ny=2,
         nz=2,
         restarted_from_step=0,
-        num_keywords=3 + len(summary_keys),
+        num_keywords=len(keywords),
         restart="        ",
-        keywords=["DAY     ", "MONTH   ", "YEAR    ", *summary_keys],
+        keywords=keywords,
         well_names=[
-            ":+:+:+:+",
-            ":+:+:+:+",
-            ":+:+:+:+",
+            *([":+:+:+:+"] * len(date_keywords)),
             *(["A_NAME  "] * len(summary_keys)),
         ],
-        region_numbers=[-32676, -32676, -32676, *([0] * len(summary_keys))],
-        units=["        ", "        ", "        ", *(["SM3"] * len(summary_keys))],
-        start_date=start_date,
+        region_numbers=[
+            *([-32676] * len(date_keywords)),
+            *([0] * len(summary_keys)),
+        ],
+        units=[
+            *(["        "] * len(date_keywords)),
+            *(["SM3"] * len(summary_keys)),
+        ],
+        start_date=Date(day=1, month=1, year=2010, hour=0, minutes=0, micro_seconds=0),
         intehead=SmspecIntehead(
             unit=ResfoUnitSystem.METRIC,
             simulator=Simulator.ECLIPSE_100,
         ),
     )
-
-    expected_dates = [
-        datetime.datetime(2010, 1, 1),
-        datetime.datetime(2010, 3, 15),
-    ]
-    expected_values = [10.0, 20.0]
     unsmry = Unsmry(
         steps=[
             SummaryStep(
                 seqnum=0,
                 ministeps=[
-                    SummaryMiniStep(mini_step=0, params=[1.0, 1.0, 2010.0, 10.0])
+                    SummaryMiniStep(
+                        mini_step=0,
+                        params=[*([1.0] * len(date_keywords)), 10.0],
+                    )
                 ],
-            ),
-            SummaryStep(
-                seqnum=1,
-                ministeps=[
-                    SummaryMiniStep(mini_step=1, params=[15.0, 3.0, 2010.0, 20.0])
-                ],
-            ),
+            )
         ]
     )
     smspec.to_file(f"{case}.SMSPEC")
     unsmry.to_file(f"{case}.UNSMRY")
 
-    summary = Summary(case)
-    assert summary.dates == expected_dates
-    assert list(summary["FOPT"].values) == expected_values
-    assert summary.start_date == datetime.date(2010, 1, 1)
+    with pytest.raises(ValueError, match="lack time information"):
+        Summary(case, lazy_load=lazy_load)
 
 
 def test_that_summary_keyword_vector_lifetime_is_longer_than_summary():


### PR DESCRIPTION
The goal of this PR is to make some progress towards not using internal vector types. I needed to resolve some bugs and design issues before that is possible.

This resolves severals bugs related to type conversions and having bad states representable:

1. parser.cpp would alias EOF by not using int as the return type for fgetc.
2. smspec would not always switch between representations of time
3. There was a long standing regression with select_box