### PR TITLE
Validate `lgr_nr`

### DIFF
--- a/lib/resdata/rd_grid.cpp
+++ b/lib/resdata/rd_grid.cpp
@@ -1802,10 +1802,13 @@ static void rd_grid_init_mapaxes(rd_grid_type *rd_grid, bool apply_mapaxes,
 */
 static rd_grid_type *rd_grid_add_lgr(rd_grid_type *main_grid,
                                      rd_grid_ptr lgr_grid) {
+    int lgr_nr = lgr_grid->lgr_nr;
+    if (lgr_nr < 0)
+        throw std::invalid_argument(
+            fmt::format("LGR number must be non-negative, got {}", lgr_nr));
+
     auto ptr = lgr_grid.get();
     std::string lgr_name = lgr_grid->name;
-    int lgr_nr = lgr_grid->lgr_nr;
-
     main_grid->LGR_list.push_back(std::move(lgr_grid));
     if (lgr_nr >= static_cast<int>(main_grid->lgr_index_map.size()))
         main_grid->lgr_index_map.resize(lgr_nr + 1, 0);
@@ -2097,6 +2100,10 @@ static rd_grid_ptr rd_grid_alloc_GRDECL_kw__(
     if (nx <= 0 || ny <= 0 || nz <= 0)
         throw std::invalid_argument(fmt::format(
             "Invalid grid dimensions: nx={}, ny={}, nz={}", nx, ny, nz));
+
+    if (lgr_nr < 0)
+        throw std::invalid_argument(
+            fmt::format("Invalid lgr_nr: lgr_nr={}", lgr_nr));
 
     const int64_t nx64 = nx;
     const int64_t ny64 = ny;

--- a/lib/resdata/rd_grid.cpp
+++ b/lib/resdata/rd_grid.cpp
@@ -1807,6 +1807,15 @@ static rd_grid_type *rd_grid_add_lgr(rd_grid_type *main_grid,
         throw std::invalid_argument(
             fmt::format("LGR number must be non-negative, got {}", lgr_nr));
 
+    // Bound check for LGR number to avoid excessive memory allocation in
+    // lgr_index_map. Value was choses arbitrarily, but should be large enough
+    // for any reasonable case.
+    constexpr int MAX_LGR_NR = 1'000'000;
+    if (lgr_nr > MAX_LGR_NR)
+        throw std::invalid_argument(
+            fmt::format("LGR number {} exceeds maximum supported value {}",
+                        lgr_nr, MAX_LGR_NR));
+
     auto ptr = lgr_grid.get();
     std::string lgr_name = lgr_grid->name;
     main_grid->LGR_list.push_back(std::move(lgr_grid));

--- a/tests/rd_tests/_grid_fixtures.py
+++ b/tests/rd_tests/_grid_fixtures.py
@@ -271,6 +271,7 @@ def write_egrid_with_single_lgr(
     mapaxes: Sequence[float] | None = None,
     nncg: Sequence[int] = (),
     nncl: Sequence[int] = (),
+    lgr_nr: int = 1,
 ) -> None:
     main_grid = make_rectangular_grid(nx, ny, nz, 1.0, 1.0, 1.0)
     lgr_grid = make_rectangular_grid(
@@ -286,8 +287,8 @@ def write_egrid_with_single_lgr(
         _write_grid_body(f, main_grid)
         write_empty_kw(f, ENDGRID_KW)
 
-        _write_lgr_egrid_section(f, lgr_name, "", 1, lgr_grid, host_global + 1)
-        _write_nnc_pair(f, 1, NNCG_KW, NNCL_KW, nncg, nncl)
+        _write_lgr_egrid_section(f, lgr_name, "", lgr_nr, lgr_grid, host_global + 1)
+        _write_nnc_pair(f, lgr_nr, NNCG_KW, NNCL_KW, nncg, nncl)
 
 
 def write_egrid_with_nested_lgr(

--- a/tests/rd_tests/test_rd_grid_nnc_lgr.py
+++ b/tests/rd_tests/test_rd_grid_nnc_lgr.py
@@ -59,6 +59,29 @@ def test_that_egrid_with_negative_lgr_number_raises(tmp_path):
         Grid(str(filename))
 
 
+def test_that_egrid_with_lgr_number_above_upper_bound_raises(tmp_path):
+    filename = tmp_path / "TOO_LARGE_LGR_NUMBER.EGRID"
+    write_egrid_with_single_lgr(
+        filename,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        "LGR1",
+        lgr_nr=1_000_001,
+    )
+
+    with pytest.raises(
+        ValueError, match="LGR number 1000001 exceeds maximum supported value"
+    ):
+        Grid(str(filename))
+
+
 def test_that_lgr_grid_has_expected_dimensions(tmp_path):
     grid = load_egrid_with_single_lgr(
         tmp_path / "LGR_DIMS.EGRID",

--- a/tests/rd_tests/test_rd_grid_nnc_lgr.py
+++ b/tests/rd_tests/test_rd_grid_nnc_lgr.py
@@ -15,6 +15,7 @@ from ._grid_fixtures import (
     load_grid_file_with_lgr_parent,
     load_grid_file_with_mapaxes,
     load_grid_file_with_nested_lgr,
+    write_egrid_with_single_lgr,
 )
 
 
@@ -35,6 +36,27 @@ def test_that_egrid_with_single_lgr_reports_one_lgr(tmp_path):
 
     assert grid.get_num_lgr() == 1
     assert grid.has_lgr("LGR1")
+
+
+def test_that_egrid_with_negative_lgr_number_raises(tmp_path):
+    filename = tmp_path / "NEGATIVE_LGR_NUMBER.EGRID"
+    write_egrid_with_single_lgr(
+        filename,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        "LGR1",
+        lgr_nr=-1000,
+    )
+
+    with pytest.raises(ValueError, match="Invalid lgr_nr: lgr_nr=-1000"):
+        Grid(str(filename))
 
 
 def test_that_lgr_grid_has_expected_dimensions(tmp_path):


### PR DESCRIPTION
**Approach**
Check if `lgr_nr` is negative or too large and reject it. I use `1 000 000` as upper bound, but I don't really know if this is a good upper bound or not. I expect that we would not have more local grid refinements than that.

I think we could also fix it more thoroughly if we would make `lgr_index_map` a `std::unordered_map`, since the comment also mentions

> Cases have popped up where the series of GRIDHEAD(4) values from lgr to lgr have holes :-(

If this is worth it, we could go foor `std::unordered_map` instead. I tried to keep it simple for now since there are other changes lined up that will resolve the issue