### PR TITLE
Validate RPORV size against active cell count

### DIFF
--- a/lib/resdata/rd_grav.cpp
+++ b/lib/resdata/rd_grav.cpp
@@ -491,18 +491,24 @@ static void rd_grav_survey_assert_RPORV(const rd_grav_survey_type *survey,
 static rd_grav_survey_type *
 rd_grav_survey_alloc_RPORV(rd_grav_type *rd_grav, rd::FileView *restart_file,
                            const std::string &name) {
-    rd_grav_survey_type *survey =
-        rd_grav_survey_alloc_empty(rd_grav, name, GRAV_CALC_RPORV);
-
-    if (restart_file->has_kw(RPORV_KW)) {
-        rd_kw_type *rporv_kw = restart_file->get_kw(RPORV_KW, 0);
-        int iactive;
-        for (iactive = 0; iactive < rd_kw_get_size(rporv_kw); iactive++)
-            survey->porv[iactive] = rd_kw_iget_as_double(rporv_kw, iactive);
-    } else
+    if (!restart_file->has_kw(RPORV_KW))
         throw std::runtime_error(std::string(__func__) +
                                  ": restart file did not contain " + RPORV_KW +
                                  " keyword");
+
+    rd_kw_type *rporv_kw = restart_file->get_kw(RPORV_KW, 0);
+    const int active_size = rd_grav->grid_cache->size();
+    const int rporv_size = rd_kw_get_size(rporv_kw);
+    if (rporv_size != active_size)
+        throw std::invalid_argument(
+            fmt::format("{} keyword has {} elements, but the grid has {} "
+                        "active cells",
+                        RPORV_KW, rporv_size, active_size));
+
+    rd_grav_survey_type *survey =
+        rd_grav_survey_alloc_empty(rd_grav, name, GRAV_CALC_RPORV);
+    for (int iactive = 0; iactive < active_size; iactive++)
+        survey->porv[iactive] = rd_kw_iget_as_double(rporv_kw, iactive);
 
     {
         const rd::File *init_file = rd_grav->init_file;

--- a/tests/rd_tests/test_grav.py
+++ b/tests/rd_tests/test_grav.py
@@ -464,3 +464,65 @@ class ResdataGravTest(ResdataTest):
                 match=r"substantially different from the initial porv value",
             ):
                 grav.add_survey_RPORV("rporv", restart_view)
+
+    def test_that_oversized_rporv_raises(self):
+        rporv = ResdataKW(
+            "RPORV",
+            self.grid.get_num_active() + 1,
+            ResDataType.RD_FLOAT,
+        )
+        rporv.assign(0.5)
+        kws = [
+            self._float_kw(name)
+            for name in [
+                "PORO",
+                "PORV",
+                "SWAT",
+                "SGAS",
+                "OIL_DEN",
+                "GAS_DEN",
+                "WAT_DEN",
+            ]
+        ]
+        kws.append(rporv)
+
+        tmpdir = self.tmp_path_factory.mktemp("grav_oversized_rporv", numbered=True)
+        with self.monkeypatch.context() as mp:
+            grav, restart_view = self._all_phase_grav(tmpdir, mp, kws)
+
+            with pytest.raises(
+                ValueError,
+                match=r"RPORV.*elements.*active cells",
+            ):
+                grav.add_survey_RPORV("rporv", restart_view)
+
+    def test_that_undersized_rporv_raises(self):
+        rporv = ResdataKW(
+            "RPORV",
+            self.grid.get_num_active() - 1,
+            ResDataType.RD_FLOAT,
+        )
+        rporv.assign(0.5)
+        kws = [
+            self._float_kw(name)
+            for name in [
+                "PORO",
+                "PORV",
+                "SWAT",
+                "SGAS",
+                "OIL_DEN",
+                "GAS_DEN",
+                "WAT_DEN",
+            ]
+        ]
+        kws.append(rporv)
+
+        tmpdir = self.tmp_path_factory.mktemp("grav_undersized_rporv", numbered=True)
+        with self.monkeypatch.context() as mp:
+            grav, restart_view = self._all_phase_grav(tmpdir, mp, kws)
+
+            with pytest.raises(
+                ValueError,
+                match=r"RPORV.*elements.*active cells",
+            ):
+                grav.add_survey_RPORV("rporv", restart_view)


### PR DESCRIPTION
add_survey_RPORV read data from the RPORV keyword without checking that its size matches the grid's active cell count. Reject the restart file with a clear error if the sizes differ, and add tests covering both oversized and undersized RPORV keywords.
