### PR TITLE
Backport improved validation to version 6.3

### DIFF
--- a/lib/resdata/rd_grav.cpp
+++ b/lib/resdata/rd_grav.cpp
@@ -455,18 +455,26 @@ static rd_grav_survey_type *
 rd_grav_survey_alloc_RPORV(rd_grav_type *rd_grav,
                            const rd_file_view_type *restart_file,
                            const char *name) {
-    rd_grav_survey_type *survey =
-        rd_grav_survey_alloc_empty(rd_grav, name, GRAV_CALC_RPORV);
-
-    if (rd_file_view_has_kw(restart_file, RPORV_KW)) {
-        rd_kw_type *rporv_kw =
-            rd_file_view_iget_named_kw(restart_file, RPORV_KW, 0);
-        int iactive;
-        for (iactive = 0; iactive < rd_kw_get_size(rporv_kw); iactive++)
-            survey->porv[iactive] = rd_kw_iget_as_double(rporv_kw, iactive);
-    } else
+    if (!rd_file_view_has_kw(restart_file, RPORV_KW))
         util_abort("%s: restart file did not contain %s keyword??\n", __func__,
                    RPORV_KW);
+
+    rd_kw_type *rporv_kw =
+        rd_file_view_iget_named_kw(restart_file, RPORV_KW, 0);
+    const int active_size = rd_grav->grid_cache->size();
+    const int rporv_size = rd_kw_get_size(rporv_kw);
+    if (rporv_size != active_size) {
+        fprintf(stderr,
+                "%s: %s keyword has %d elements, but the grid has %d "
+                "active cells\n",
+                __func__, RPORV_KW, rporv_size, active_size);
+        return NULL;
+    }
+
+    rd_grav_survey_type *survey =
+        rd_grav_survey_alloc_empty(rd_grav, name, GRAV_CALC_RPORV);
+    for (int iactive = 0; iactive < active_size; iactive++)
+        survey->porv[iactive] = rd_kw_iget_as_double(rporv_kw, iactive);
 
     {
         const rd_file_type *init_file = rd_grav->init_file;

--- a/lib/resdata/rd_grid.cpp
+++ b/lib/resdata/rd_grid.cpp
@@ -1863,10 +1863,13 @@ static void rd_grid_init_mapaxes(rd_grid_type *rd_grid, bool apply_mapaxes,
 
 static rd_grid_type *rd_grid_add_lgr(rd_grid_type *main_grid,
                                      rd_grid_ptr lgr_grid) {
+    int lgr_nr = lgr_grid->lgr_nr;
+    if (lgr_nr < 0)
+        throw std::invalid_argument(
+            fmt::format("LGR number must be non-negative, got {}", lgr_nr));
+
     auto ptr = lgr_grid.get();
     std::string lgr_name = lgr_grid->name;
-    int lgr_nr = lgr_grid->lgr_nr;
-
     main_grid->LGR_list.push_back(std::move(lgr_grid));
     if (lgr_nr >= static_cast<int>(main_grid->lgr_index_map.size()))
         main_grid->lgr_index_map.resize(lgr_nr + 1, 0);
@@ -2167,6 +2170,10 @@ static rd_grid_ptr rd_grid_alloc_GRDECL_kw__(
     if (nx <= 0 || ny <= 0 || nz <= 0)
         throw std::invalid_argument(fmt::format(
             "Invalid grid dimensions: nx={}, ny={}, nz={}", nx, ny, nz));
+
+    if (lgr_nr < 0)
+        throw std::invalid_argument(
+            fmt::format("Invalid lgr_nr: lgr_nr={}", lgr_nr));
 
     const int64_t nx64 = nx;
     const int64_t ny64 = ny;

--- a/lib/resdata/rd_grid.cpp
+++ b/lib/resdata/rd_grid.cpp
@@ -1868,6 +1868,15 @@ static rd_grid_type *rd_grid_add_lgr(rd_grid_type *main_grid,
         throw std::invalid_argument(
             fmt::format("LGR number must be non-negative, got {}", lgr_nr));
 
+    // Bound check for LGR number to avoid excessive memory allocation in
+    // lgr_index_map. Value was choses arbitrarily, but should be large enough
+    // for any reasonable case.
+    constexpr int MAX_LGR_NR = 1'000'000;
+    if (lgr_nr > MAX_LGR_NR)
+        throw std::invalid_argument(
+            fmt::format("LGR number {} exceeds maximum supported value {}",
+                        lgr_nr, MAX_LGR_NR));
+
     auto ptr = lgr_grid.get();
     std::string lgr_name = lgr_grid->name;
     main_grid->LGR_list.push_back(std::move(lgr_grid));

--- a/python/resdata/gravimetry/rd_grav.py
+++ b/python/resdata/gravimetry/rd_grav.py
@@ -107,7 +107,12 @@ class ResdataGrav(BaseCClass):
         add_survey_PORMOD() and add_survey_FIP() are alternatives
         which are based on other keywords.
         """
-        self._add_survey_RPORV(survey_name, restart_view)
+        void_ptr = self._add_survey_RPORV(survey_name, restart_view)
+        if void_ptr is None:
+            raise ValueError(
+                "Could not add RPORV survey: RPORV keyword size does not "
+                "match the number of active cells in the grid"
+            )
 
     def add_survey_PORMOD(
         self, survey_name: str, restart_view: ResdataFileView

--- a/tests/rd_tests/_grid_fixtures.py
+++ b/tests/rd_tests/_grid_fixtures.py
@@ -243,6 +243,7 @@ def write_egrid_with_single_lgr(
     mapaxes: Sequence[float] | None = None,
     nncg: Sequence[int] = (),
     nncl: Sequence[int] = (),
+    lgr_nr: int = 1,
 ) -> None:
     main_grid = make_rectangular_grid(nx, ny, nz, 1.0, 1.0, 1.0)
     lgr_grid = make_rectangular_grid(
@@ -258,8 +259,8 @@ def write_egrid_with_single_lgr(
         _write_grid_body(f, main_grid)
         write_empty_kw(f, ENDGRID_KW)
 
-        _write_lgr_egrid_section(f, lgr_name, "", 1, lgr_grid, host_global + 1)
-        _write_nnc_pair(f, 1, NNCG_KW, NNCL_KW, nncg, nncl)
+        _write_lgr_egrid_section(f, lgr_name, "", lgr_nr, lgr_grid, host_global + 1)
+        _write_nnc_pair(f, lgr_nr, NNCG_KW, NNCL_KW, nncg, nncl)
 
 
 def write_egrid_with_nested_lgr(

--- a/tests/rd_tests/test_grav.py
+++ b/tests/rd_tests/test_grav.py
@@ -134,3 +134,61 @@ class ResdataGravTest(ResdataTest):
             grav.add_std_density(1, 0, 0.5)
 
             grav.add_survey_RPORV("rporv", restart_view)
+
+    def test_that_oversized_rporv_raises(self):
+        kws = [
+            ResdataKW(kw, self.grid.get_global_size(), ResDataType.RD_FLOAT)
+            for kw in [
+                "PORO",
+                "PORV",
+                "SWAT",
+                "OIL_DEN",
+            ]
+        ]
+        rporv = ResdataKW("RPORV", self.grid.get_num_active() + 1, ResDataType.RD_FLOAT)
+        rporv.assign(0.5)
+        kws.append(rporv)
+
+        with TestAreaContext("grav_oversized_rporv"):
+            write_kws("TEST", kws)
+            init = ResdataFile("TEST.INIT")
+
+            grav = ResdataGrav(self.grid, init)
+
+            restart_file = ResdataFile("TEST.UNRST")
+            restart_view = restart_file.restart_view(sim_time=datetime.date(2000, 1, 1))
+
+            grav.new_std_density(1, 0.5)
+            grav.add_std_density(1, 0, 0.5)
+
+            with self.assertRaises(ValueError):
+                grav.add_survey_RPORV("rporv", restart_view)
+
+    def test_that_undersized_rporv_raises(self):
+        kws = [
+            ResdataKW(kw, self.grid.get_global_size(), ResDataType.RD_FLOAT)
+            for kw in [
+                "PORO",
+                "PORV",
+                "SWAT",
+                "OIL_DEN",
+            ]
+        ]
+        rporv = ResdataKW("RPORV", self.grid.get_num_active() - 1, ResDataType.RD_FLOAT)
+        rporv.assign(0.5)
+        kws.append(rporv)
+
+        with TestAreaContext("grav_undersized_rporv"):
+            write_kws("TEST", kws)
+            init = ResdataFile("TEST.INIT")
+
+            grav = ResdataGrav(self.grid, init)
+
+            restart_file = ResdataFile("TEST.UNRST")
+            restart_view = restart_file.restart_view(sim_time=datetime.date(2000, 1, 1))
+
+            grav.new_std_density(1, 0.5)
+            grav.add_std_density(1, 0, 0.5)
+
+            with self.assertRaises(ValueError):
+                grav.add_survey_RPORV("rporv", restart_view)

--- a/tests/rd_tests/test_rd_grid_nnc_lgr.py
+++ b/tests/rd_tests/test_rd_grid_nnc_lgr.py
@@ -59,6 +59,29 @@ def test_that_egrid_with_negative_lgr_number_raises(tmp_path):
         Grid(str(filename))
 
 
+def test_that_egrid_with_lgr_number_above_upper_bound_raises(tmp_path):
+    filename = tmp_path / "TOO_LARGE_LGR_NUMBER.EGRID"
+    write_egrid_with_single_lgr(
+        filename,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        "LGR1",
+        lgr_nr=1_000_001,
+    )
+
+    with pytest.raises(
+        ValueError, match="LGR number 1000001 exceeds maximum supported value"
+    ):
+        Grid(str(filename))
+
+
 def test_that_lgr_grid_has_expected_dimensions(tmp_path):
     grid = load_egrid_with_single_lgr(
         tmp_path / "LGR_DIMS.EGRID",

--- a/tests/rd_tests/test_rd_grid_nnc_lgr.py
+++ b/tests/rd_tests/test_rd_grid_nnc_lgr.py
@@ -15,6 +15,7 @@ from ._grid_fixtures import (
     load_grid_file_with_lgr_parent,
     load_grid_file_with_mapaxes,
     load_grid_file_with_nested_lgr,
+    write_egrid_with_single_lgr,
 )
 
 
@@ -35,6 +36,27 @@ def test_that_egrid_with_single_lgr_reports_one_lgr(tmp_path):
 
     assert grid.get_num_lgr() == 1
     assert grid.has_lgr("LGR1")
+
+
+def test_that_egrid_with_negative_lgr_number_raises(tmp_path):
+    filename = tmp_path / "NEGATIVE_LGR_NUMBER.EGRID"
+    write_egrid_with_single_lgr(
+        filename,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0,
+        "LGR1",
+        lgr_nr=-1000,
+    )
+
+    with pytest.raises(ValueError, match="Invalid lgr_nr: lgr_nr=-1000"):
+        Grid(str(filename))
 
 
 def test_that_lgr_grid_has_expected_dimensions(tmp_path):


### PR DESCRIPTION
Recently improved validation of `lgr_nr` and `rporv` backported to version 6.3.

I need feedback if returning `NULL`  instead of using `util_abort` in `rd_grav_survey_alloc_RPORV` is a good idea. It follows the same pattern (return `NULL`) used in `rd_grav_survey_alloc_FIP`.